### PR TITLE
New Database Seed Script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,6 @@ restart: stop run
 
 generate-local-data:
 	@echo 'Generating local data ...'
-	@docker-compose -f docker/dev/docker-compose.yml --env-file .env run --rm app bash -c "PYTHONPATH=/app uv run python scripts/database/seed.py --sample-data --vector-data chunks_BAAI.json"
+	@docker-compose -f docker/dev/docker-compose.yml --env-file .env run --rm app bash -c "PYTHONPATH=/app uv run python scripts/database/seed.py --create --sample-data --vector-data chunks_BAAI.json"
 
 setup-env: build generate-local-data run

--- a/app/config.py
+++ b/app/config.py
@@ -41,6 +41,11 @@ class Settings(BaseSettings):
     # Database settings
     database_url: SecretStr
 
+    @property
+    def sync_database_url(self) -> str:
+        """Get synchronous database URL for migrations"""
+        return self.database_url.get_secret_value().replace("+asyncpg", "")
+
     # Business environment
     business_env: bool = False  # Default if not found in .env
 

--- a/docs/en/GETTING_STARTED.md
+++ b/docs/en/GETTING_STARTED.md
@@ -137,10 +137,6 @@ Next up, let's build all Docker images and local data, needed for further steps 
 make setup-env
 ```
 
-> [!Note]
->
-> You can try out [TablePlus](https://tableplus.com/) to visualize your databases.
-
 ## 🖥️ Set up the FastAPI application
 
 Run the following command to run the project.

--- a/docs/en/MIGRATIONS.md
+++ b/docs/en/MIGRATIONS.md
@@ -1,0 +1,13 @@
+# Migrations
+
+You might run into some database troubles that require you to do database migrations. In the folder `migrations/versions/` you find the list of past database migrations. We're using [Alembic](https://alembic.sqlalchemy.org/en/latest/). They're docs aren't great so here's a beginner [article](https://medium.com/@kasperjuunge/how-to-get-started-with-alembic-and-sqlmodel-288700002543) on it.
+
+By default, our Docker images use the alembic versioning system to initialize the database. If you wan't to rebuild the database to your needs, you can run new migrations and rebuild the Docker containers.
+
+If you're not using Docker to run Twiga, then you can initialize the database and inject seed data with the command:
+
+```
+uv run python -m scripts.database.seed --create --sample-data --vector-data chunks_BAAI.json
+```
+
+This will remove all tables in the database if they exist, create new ones, install pgvector and inject sample data and vector data so that the database is ready to accept new users.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -15,7 +15,7 @@ from app.database.models import *  # noqa: F403
 config = context.config
 
 # Load PostgreSQL migrations URL from environment variables
-db_url = settings.database_url.get_secret_value()
+db_url = settings.sync_database_url
 print(f"Connecting to: {db_url}")
 config.set_main_option("sqlalchemy.url", db_url)
 

--- a/scripts/database/seed.py
+++ b/scripts/database/seed.py
@@ -1,7 +1,7 @@
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 import json
 from pathlib import Path
-from sqlalchemy import text
+from sqlmodel import text
 from sqlmodel import SQLModel, select
 import logging
 from typing import List, Dict, Any
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 async def reset_db():
+    """Reset database using async operations"""
     try:
         engine = create_async_engine(get_database_url())
         async with engine.begin() as conn:
@@ -33,7 +34,6 @@ async def reset_db():
             await conn.execute(text("DROP TABLE IF EXISTS alembic_version CASCADE"))
 
             logger.info("Dropping existing enum types...")
-            # TODO: Validate that this works
             enum_query = """
                 SELECT t.typname FROM pg_type t
                 JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace


### PR DESCRIPTION
# What changed
I updated the database seed script to use alembic migrations. Now the command `python -m scripts.database.seed --create --sample-data --vector-data chunks_BAAI.json` resets the database, runs the alembic migrations, and adds seed data (chunks as well), all while keeping in sync with alembic versioning. 

I also made the Makefile use the same. 