### PR TITLE
Fix getting started link in README (KTH-59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Here are a couple of screenshots. Alternatively, you can take a look at our brie
 
 ## 🤝 Get involved
 
-We encourage you to contribute to Twiga! There is plenty of documentation describing the current [architecture](https://github.com/Tanzania-AI-Community/twiga/blob/main/docs/en/ARCHITECTURE.md) of Twiga, how to [contribute](https://github.com/Tanzania-AI-Community/twiga/blob/main/docs/en/CONTRIBUTING.md), and how to [get started](https://github.com/Tanzania-AI-Community/twiga/blob/documentation/docs/en/GETTING_STARTED.md) in the `docs/` folder.
+We encourage you to contribute to Twiga! There is plenty of documentation describing the current [architecture](https://github.com/Tanzania-AI-Community/twiga/blob/main/docs/en/ARCHITECTURE.md) of Twiga, how to [contribute](https://github.com/Tanzania-AI-Community/twiga/blob/main/docs/en/CONTRIBUTING.md), and how to [get started](https://github.com/Tanzania-AI-Community/twiga/blob/main/docs/en/GETTING_STARTED.md) in the `docs/` folder.
 
 For further support you can join our [Discord](https://discord.gg/bCe2HfZY2C) to discuss directly with the community and stay up to date on what's happening, or you can contact us more formally using GitHub [Discussions](https://github.com/Tanzania-AI-Community/twiga/discussions).
 


### PR DESCRIPTION
Updated the link to the "Getting Started Guide" in README. 