### PR TITLE
Character limiting pre-LLM call

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -71,6 +71,8 @@ class Settings(BaseSettings):
         if isinstance(v, str):
             return v.lower() in ("true", "True")
         return False
+    
+
 
 
 class LLMSettings(BaseSettings):
@@ -92,7 +94,22 @@ class LLMSettings(BaseSettings):
         "llama_3_3_70b": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
         "mixtral": "mistralai/Mixtral-8x7B-Instruct-v0.1",
         "gpt-4o": "gpt-4o",
-        "gpt-4o_mini": "gpt-40-mini",
+        "gpt-4o_mini": "gpt-4o-mini",
+    }
+    
+    tokenizer_options: dict = {
+        "llama_405b": "meta-llama/Llama-3.1-405B",
+        "llama_70b": "meta-llama/Llama-3.1-70B-Instruct",
+        "llama_3_3_70b": "meta-llama/Llama-3.3-70B-Instruct",
+    }
+    
+    llm_context_window_lengths: dict = {
+        "llama_405b": 128000,  
+        "llama_70b": 128000,     
+        "llama_3_3_70b": 128000, 
+        "mixtral": 32000,      
+        "gpt-4o": 128000,    
+        "gpt-4o_mini": 128000
     }
 
     embedder_model_options: dict = {
@@ -104,10 +121,12 @@ class LLMSettings(BaseSettings):
     XXX: FILL YOUR AI PROVIDER AND MODEL CHOICES HERE (DEFAULTS ARE PREFILLED)
      - make sure your choice of LLM, embedder, and ai_provider are compatible
     """
-    ai_provider: Literal["together", "openai"] = "together"
-    llm_model_name: str = llm_model_options["llama_3_3_70b"]
-    exercise_generator_model: str = llm_model_options["llama_70b"]
-    embedding_model: str = embedder_model_options["bge-large"]
+    ai_provider: Literal["together", "openai"] = "openai"
+    llm_model_name: str = llm_model_options["gpt-4o_mini"]
+    tokenizer_type: Literal["openai", "llama"] = "llama"
+    tokenizer_name: str = tokenizer_options["llama_3_3_70b"]
+    exercise_generator_model: str = llm_model_options["gpt-4o_mini"]
+    embedding_model: str = embedder_model_options["text-embedding-3-small"]
 
 
 def initialize_settings():

--- a/app/config.py
+++ b/app/config.py
@@ -37,7 +37,7 @@ class Settings(BaseSettings):
     whatsapp_api_token: SecretStr
     
     # Message limiting settings
-    message_character_limit: int = 65000 # in 
+    message_character_limit: int = 65000
 
     # Database settings
     database_url: SecretStr
@@ -96,15 +96,6 @@ class LLMSettings(BaseSettings):
         "mixtral": "mistralai/Mixtral-8x7B-Instruct-v0.1",
         "gpt-4o": "gpt-4o",
         "gpt-4o_mini": "gpt-4o-mini",
-    }
-    
-    llm_context_window_lengths: dict = {
-        "llama_405b": 128000,  
-        "llama_70b": 128000,     
-        "llama_3_3_70b": 128000, 
-        "mixtral": 32000,      
-        "gpt-4o": 128000,    
-        "gpt-4o_mini": 128000
     }
 
     embedder_model_options: dict = {

--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,9 @@ class Settings(BaseSettings):
     whatsapp_cloud_number_id: str
     whatsapp_verify_token: SecretStr
     whatsapp_api_token: SecretStr
+    
+    # Message limiting settings
+    message_character_limit: int = 65000 # in 
 
     # Database settings
     database_url: SecretStr
@@ -73,8 +76,6 @@ class Settings(BaseSettings):
         return False
     
 
-
-
 class LLMSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=os.getenv("TWIGA_ENV", ".env"),
@@ -97,12 +98,6 @@ class LLMSettings(BaseSettings):
         "gpt-4o_mini": "gpt-4o-mini",
     }
     
-    tokenizer_options: dict = {
-        "llama_405b": "meta-llama/Llama-3.1-405B",
-        "llama_70b": "meta-llama/Llama-3.1-70B-Instruct",
-        "llama_3_3_70b": "meta-llama/Llama-3.3-70B-Instruct",
-    }
-    
     llm_context_window_lengths: dict = {
         "llama_405b": 128000,  
         "llama_70b": 128000,     
@@ -123,8 +118,6 @@ class LLMSettings(BaseSettings):
     """
     ai_provider: Literal["together", "openai"] = "openai"
     llm_model_name: str = llm_model_options["gpt-4o_mini"]
-    tokenizer_type: Literal["openai", "llama"] = "llama"
-    tokenizer_name: str = tokenizer_options["llama_3_3_70b"]
     exercise_generator_model: str = llm_model_options["gpt-4o_mini"]
     embedding_model: str = embedder_model_options["text-embedding-3-small"]
 

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -237,8 +237,9 @@ class Message(SQLModel, table=True):
     @classmethod
     def from_api_format(cls, data: dict, user_id: int) -> "Message":
         """Create message from OpenAI API format"""
+        
         tool_calls = data.get("tool_calls")
-        if len(data["tool_calls"]) == 0:
+        if data["tool_calls"] is None or len(data["tool_calls"]) == 0:
             tool_calls = None
 
         message_data = {

--- a/app/utils/llm_utils.py
+++ b/app/utils/llm_utils.py
@@ -7,6 +7,8 @@ import backoff
 import openai
 from openai.types.chat import ChatCompletion
 from transformers import AutoTokenizer
+import huggingface_hub
+import os
 
 from app.config import llm_settings
 
@@ -28,6 +30,7 @@ def num_tokens(string: str, tokenizer_type: str = "openai") -> int:
         encoder = tiktoken.encoding_for_model(llm_settings.llm_model_name)
         return len(encoder.encode(string))
     elif llm_settings.tokenizer_type == "llama":
+        huggingface_hub.login(token=os.getenv("HF_TOKEN", ".env"))
         tokenizer = AutoTokenizer.from_pretrained(llm_settings.tokenizer_name)  
         logger.debug(f"Tokenizer: {tokenizer}")
         return len(tokenizer.tokenize(string))
@@ -63,9 +66,7 @@ async def async_llm_request(
         
         if verbose:
             messages = params.get("messages", None)
-            messages_string = json.dumps(messages, indent=2)       
-            logger.info(f"Messages sent to LLM API:\n{messages}")
-            logger.info(f"Number of tokens / characters in payload:{num_tokens(messages_string)} / {len(messages_string)}")
+            logger.info(f"Messages sent to LLM API:\n{json.dumps(messages, indent=2)}")  
 
         completion = await llm_client.chat.completions.create(**params)
 

--- a/app/utils/llm_utils.py
+++ b/app/utils/llm_utils.py
@@ -23,21 +23,6 @@ if llm_settings.ai_provider == "together" and llm_settings.llm_api_key:
 elif llm_settings.ai_provider == "openai" and llm_settings.llm_api_key:
     llm_client = openai.AsyncOpenAI(api_key=llm_settings.llm_api_key.get_secret_value())
 
-def num_tokens(string: str, tokenizer_type: str = "openai") -> int:
-    """This returns the number of tokens in a text string with either OpenAI's tiktoken or Meta's LLama tokenizer."""
-    
-    if llm_settings.tokenizer_type == "openai":
-        encoder = tiktoken.encoding_for_model(llm_settings.llm_model_name)
-        return len(encoder.encode(string))
-    elif llm_settings.tokenizer_type == "llama":
-        huggingface_hub.login(token=os.getenv("HF_TOKEN", ".env"))
-        tokenizer = AutoTokenizer.from_pretrained(llm_settings.tokenizer_name)  
-        logger.debug(f"Tokenizer: {tokenizer}")
-        return len(tokenizer.tokenize(string))
-    else:
-        raise ValueError("Invalid tokenizer type - see config.py for valid options.")
-    
-
 
 @backoff.on_exception(backoff.expo, openai.RateLimitError, max_tries=7, max_time=45)
 async def async_llm_request(


### PR DESCRIPTION
Implemented character limit for message _before_ LLM API call. Important: this only checks the last message, not the last couple of messages in the history. This issue is to be solved in issue #92 on handling conversational memory. 

Other edits include:
1. Fixing tool call error that seemingly only occurs when using OpenAI LLM client
2. Removed token counting with tokenizer. Token counting with tokenizer is unnecessary when the character limiting suffices, and is computationally far cheaper. Heuristics are good enough (1 token ~ 6 characters).
3. Changed default API to OpenAPI instead of Together AI (this can always be changed)