### PR TITLE
New Feature: /devhooks Endpoint for Twiga Chatbot (MOCK_WHATSAPP Mode)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -36,6 +36,9 @@ class Settings(BaseSettings):
     whatsapp_verify_token: SecretStr
     whatsapp_api_token: SecretStr
 
+    # WhatsApp mock
+    mock_whatsapp: bool = False
+
     # Database settings
     database_url: SecretStr
 

--- a/app/main.py
+++ b/app/main.py
@@ -72,6 +72,14 @@ async def webhook_post(request: Request) -> JSONResponse:
 
     return await handle_request(request)
 
+@app.post("/devhooks")
+async def webhook_post(request: Request) -> JSONResponse:
+    logger.debug("devhooks_post is being called")
+
+    if not settings.mock_whatsapp:
+        return {"message": "mock whatsapp is disabled"}
+    return await handle_request(request)
+
 
 @app.post("/flows", dependencies=[Depends(flows_signature_required)])
 async def handle_flows_webhook(

--- a/app/services/whatsapp_service.py
+++ b/app/services/whatsapp_service.py
@@ -8,7 +8,7 @@ import httpx
 from app.config import settings
 from app.utils.logging_utils import log_httpx_response
 from app.utils.whatsapp_utils import generate_payload
-
+from app.config import settings
 
 class WhatsAppClient:
     def __init__(self):
@@ -23,6 +23,10 @@ class WhatsAppClient:
     async def send_message(
         self, wa_id: str, message: str, options: Optional[List[str]] = None
     ) -> None:
+        
+        if settings.mock_whatsapp:
+            return
+           
         try:
             payload: Dict[str, Any] = generate_payload(wa_id, message, options)
             response = await self.client.post(

--- a/app/utils/whatsapp_utils.py
+++ b/app/utils/whatsapp_utils.py
@@ -18,6 +18,8 @@ from app.models.message_models import (
     ListAction,
 )
 
+from app.config import settings
+
 
 class RequestType(Enum):
     FLOW_EVENT = auto()
@@ -186,6 +188,8 @@ def extract_message_info(body: dict) -> dict:
 
 
 def is_message_outdated(message_timestamp: int) -> bool:
+    if settings.mock_whatsapp:
+        return False
     current_timestamp = int(datetime.now().timestamp())
     return current_timestamp - message_timestamp >= 10
 


### PR DESCRIPTION
#### **Overview**  
This PR introduces a new endpoint, `/devhooks`, designed to mimic the behavior of `/webhooks`. It enables interaction with the Twiga chatbot without requiring WhatsApp.  

#### **Key Changes**  
- **New Endpoint:** `/devhooks`  
- **Functionality:**  
  - Operates similarly to `/webhooks` but allows direct interaction with Twiga chatbot.  
  - Requires the environment variable `MOCK_WHATSAPP` to be set to `True`.  
  - If `MOCK_WHATSAPP` is `False` or unset, `/webhooks` remains the default.  
- **Database Interaction:**  
  - Messages received through `/devhooks` are stored in the database and no response in sent to whatsapp.  
  - The chat UI periodically fetches responses from the database.  

#### **Request Body Example**  
```json
{
  "object": "whatsapp_business_account",
  "entry": [{
    "id": 1234567890,
    "changes": [{
      "value": {
        "messaging_product": "whatsapp",
        "metadata": {
          "display_phone_number": "255712345678",
          "phone_number_id": "9876543210"
        },
        "contacts": [{
          "profile": {
            "name": "John Doe"
          },
          "wa_id": "255712345678"
        }],
        "messages": [{
          "from": "255712345678",
          "id": "wamid.12345678910111212",
          "timestamp": 1708954872,
          "text": {
            "body": "what is topic 1 in geography form 2"
          },
          "type": "text"
        }]
      },
      "field": "messages"
    }]
  }]
}
```  

#### **Why This Is Useful**  
- Allows developers to test chatbot interactions without a WhatsApp account.  
- Simplifies debugging and internal testing.  
- Enables chatbot usage via alternative communication channels.  

#### **Next Steps**  
- Code review and testing.  
- Ensure compatibility with the existing `/webhooks` logic.  

