### PR TITLE
docs: made setup easier with ai_provider in env templates and docs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,6 +4,8 @@
 
 # API Key for the LLM provider (either OpenAI or Together AI)
 LLM_API_KEY=
+# Choose your AI provider: together / openai / ollama
+AI_PROVIDER=
 
 # LangSmith tracing configuration (optional - for monitoring and debugging LLM interactions)
 LANGSMITH_API_KEY=

--- a/.env.template.simple
+++ b/.env.template.simple
@@ -2,6 +2,8 @@
 
 # API Key for the LLM provider (either OpenAI or Together AI)
 LLM_API_KEY=
+# Choose your AI provider: together / openai / ollama
+AI_PROVIDER=
 
 # Postgres database URL
 DATABASE_USER=

--- a/docs/en/GETTING_STARTED.md
+++ b/docs/en/GETTING_STARTED.md
@@ -136,7 +136,7 @@ If you prefer to run Twiga without using Together AI or OpenAI, you can host bot
 
 4. **Restart the FastAPI stack** (`make run` or `docker-compose … up`) so that the new configuration is loaded.
 
-With this setup, Twiga sends all chat and embedding requests to your local Ollama instance. If you also keep an `LLM_API_KEY`, the app can still switch back to Together AI or OpenAI by changing `LLM__AI_PROVIDER`.
+With this setup, Twiga sends all chat and embedding requests to your local Ollama instance. If you also keep an `LLM_API_KEY`, the app can still switch back to Together AI or OpenAI by changing `AI_PROVIDER`.
 
 ## 📊 LangSmith Tracing (Optional)
 


### PR DESCRIPTION
Hi, I improved the docs after having trouble setting up the connection with TogetherAI

**Problem:**
`AI_PROVIDER` variable defaults to `ollama` in app/config.py, but this default behaviour was hard to spot for a newcomer because there was no mention of the variable.

**Solution:**
Added mention of `AI_PROVIDER` to the env templates and fixed a typo of it in GETTING_STARTED.md