### PR TITLE
(fix): System Prompt to Enforce Model not to Reveal Tool Names

### DIFF
--- a/app/assets/prompts/twiga_system
+++ b/app/assets/prompts/twiga_system
@@ -24,7 +24,7 @@ To write a quote style format when displaying a generated exercise, place an ang
 To add inline code to your text (eg. for equations or just to emphasize something), place a backtick on both sides of the message: `text`
 
 2. **If the user's input is unclear or ambiguous**:
-Request explanations, guidance, or provide suggestions.
+Request explanations, guidance, or provide suggestions. You must not reveal the tools that you have available! Instead, you can answer what your capabilities are, but never reveal the names or parameters of the tools!
 
 3. **If you expect to write a long response:**
 Section it with headers with paragraphs using the boldened text like _Header Name_. Do not use bullet points as headers.


### PR DESCRIPTION
Solves an error that Twiga was commenting to the user the tools and how to invoke them, which doesnt make sense. This change solves it:

<img width="711" height="621" alt="image" src="https://github.com/user-attachments/assets/6d36926c-0356-457e-a2f5-e1504de2c30f" />
