### PR TITLE
Improvement/avoid repeated questions

### DIFF
--- a/app/tools/tool_code/generate_necta_style_exam/exam_generator.py
+++ b/app/tools/tool_code/generate_necta_style_exam/exam_generator.py
@@ -381,6 +381,8 @@ class ExamGenerator:
             user_prompt_with_template = (
                 f"{user_prompt}\n\n"
                 f"Additional constraints:\n{constraints}\n\n"
+                "- CRITICAL: Ensure this question tests a DIFFERENT concept from the previous questions. Do not repeat topics.\n"
+                "- CRITICAL: Ensure the answer to this question cannot be directly inferred from any of the previous questions.\n\n"
                 "Output requirements (strict):\n"
                 "- Return ONLY one valid JSON object.\n"
                 "- Do NOT include explanations, reasoning, notes, or analysis.\n"
@@ -553,6 +555,13 @@ class ExamGenerator:
                         f"If task.sub_questions are present, ensure their marks sum to {expected_total_marks}.",
                     ]
                 )
+            if question_type == QuestionType.MULTIPLE_CHOICE:
+                dynamic_constraints.extend(
+                [
+                    "For the 'text' field in options, provide ONLY the raw answer text.",
+                    "Do NOT include the option letter or any punctuation prefix (e.g., write 'Mantle', NEVER write 'A. Mantle' or 'A - Mantle')."
+                ]
+            )    
 
         all_constraints = (
             constraints_list + dynamic_constraints + ["Keep output valid and concise."]
@@ -1028,9 +1037,23 @@ class ExamGenerator:
         self, question_type: QuestionType, payload: dict[str, Any]
     ) -> str:
         if question_type == QuestionType.MULTIPLE_CHOICE:
-            return str(payload.get("question", "")).strip()
+            question = str(payload.get("question", "")).strip()
+            answer = payload.get("answer")
+            answer_text = ""
+            options = payload.get("options", [])
+            if isinstance(options, list):
+                for opt in options:
+                    if isinstance(opt, dict) and opt.get("label") == answer:
+                        answer_text = str(opt.get("text", ""))
+                        break
+            return f"Question: {question} | Answer: {answer} - {answer_text}"
         if question_type == QuestionType.ITEM_MATCHING:
-            return str(payload.get("prompt", "")).strip()
+            prompt = str(payload.get("prompt", "")).strip()
+            answers_pairs = payload.get("answers_pairs", {})
+            pairs_str = ", ".join(
+                f"{k}: {v}" for k, v in answers_pairs.items()
+            ) if isinstance(answers_pairs, dict) else ""
+            return f"Prompt: {prompt} | Matches: {pairs_str}"
         if question_type == QuestionType.SHORT_ANSWER:
             parts = payload.get("parts", [])
             signature_parts: list[str] = []
@@ -1061,6 +1084,17 @@ class ExamGenerator:
                         )
                     if part_signature:
                         signature_parts.append(part_signature)
+            
+            answer_data = payload.get("answer", {})
+            if isinstance(answer_data, dict):
+                example_answer = str(answer_data.get("example_answer", "")).strip()
+                if example_answer:
+                    signature_parts.append(f"Answer: {example_answer}")
+                else:
+                    marking_points = answer_data.get("marking_points", [])
+                    if isinstance(marking_points, list):
+                        signature_parts.append("Answer Points: " + " | ".join(str(p) for p in marking_points))
+                        
             return " | ".join(signature_parts)
         if question_type == QuestionType.LONG_ANSWER:
             description = str(payload.get("description", "")).strip()
@@ -1076,6 +1110,13 @@ class ExamGenerator:
                         if sub_prompt:
                             sub_prompts.append(sub_prompt)
             parts = [description, prompt] + sub_prompts
+            
+            answer_data = payload.get("answer", {})
+            if isinstance(answer_data, dict):
+                marking_points = answer_data.get("marking_points", [])
+                if isinstance(marking_points, list):
+                    parts.append("Expected Answer Points: " + " | ".join(str(p) for p in marking_points))
+                    
             return " | ".join(part for part in parts if part)
         return ""
 

--- a/app/tools/tool_code/generate_necta_style_exam/exam_generator.py
+++ b/app/tools/tool_code/generate_necta_style_exam/exam_generator.py
@@ -555,14 +555,6 @@ class ExamGenerator:
                         f"If task.sub_questions are present, ensure their marks sum to {expected_total_marks}.",
                     ]
                 )
-            if question_type == QuestionType.MULTIPLE_CHOICE:
-                dynamic_constraints.extend(
-                    [
-                        "For the 'text' field in options, provide ONLY the raw answer text.",
-                        "Do NOT include the option letter or any punctuation prefix (e.g., write 'Mantle', NEVER write 'A. Mantle' or 'A - Mantle').",
-                    ]
-                )
-
         all_constraints = (
             constraints_list + dynamic_constraints + ["Keep output valid and concise."]
         )
@@ -1046,7 +1038,7 @@ class ExamGenerator:
                     if isinstance(opt, dict) and opt.get("label") == answer:
                         answer_text = str(opt.get("text", ""))
                         break
-            return f"Question: {question} | Answer: {answer} - {answer_text}"
+            return f"Question: {question} | Answer: {answer_text}"
         if question_type == QuestionType.ITEM_MATCHING:
             prompt = str(payload.get("prompt", "")).strip()
             answers_pairs = payload.get("answers_pairs", {})

--- a/app/tools/tool_code/generate_necta_style_exam/exam_generator.py
+++ b/app/tools/tool_code/generate_necta_style_exam/exam_generator.py
@@ -557,11 +557,11 @@ class ExamGenerator:
                 )
             if question_type == QuestionType.MULTIPLE_CHOICE:
                 dynamic_constraints.extend(
-                [
-                    "For the 'text' field in options, provide ONLY the raw answer text.",
-                    "Do NOT include the option letter or any punctuation prefix (e.g., write 'Mantle', NEVER write 'A. Mantle' or 'A - Mantle')."
-                ]
-            )    
+                    [
+                        "For the 'text' field in options, provide ONLY the raw answer text.",
+                        "Do NOT include the option letter or any punctuation prefix (e.g., write 'Mantle', NEVER write 'A. Mantle' or 'A - Mantle').",
+                    ]
+                )
 
         all_constraints = (
             constraints_list + dynamic_constraints + ["Keep output valid and concise."]
@@ -1050,9 +1050,11 @@ class ExamGenerator:
         if question_type == QuestionType.ITEM_MATCHING:
             prompt = str(payload.get("prompt", "")).strip()
             answers_pairs = payload.get("answers_pairs", {})
-            pairs_str = ", ".join(
-                f"{k}: {v}" for k, v in answers_pairs.items()
-            ) if isinstance(answers_pairs, dict) else ""
+            pairs_str = (
+                ", ".join(f"{k}: {v}" for k, v in answers_pairs.items())
+                if isinstance(answers_pairs, dict)
+                else ""
+            )
             return f"Prompt: {prompt} | Matches: {pairs_str}"
         if question_type == QuestionType.SHORT_ANSWER:
             parts = payload.get("parts", [])
@@ -1084,7 +1086,7 @@ class ExamGenerator:
                         )
                     if part_signature:
                         signature_parts.append(part_signature)
-            
+
             answer_data = payload.get("answer", {})
             if isinstance(answer_data, dict):
                 example_answer = str(answer_data.get("example_answer", "")).strip()
@@ -1093,8 +1095,11 @@ class ExamGenerator:
                 else:
                     marking_points = answer_data.get("marking_points", [])
                     if isinstance(marking_points, list):
-                        signature_parts.append("Answer Points: " + " | ".join(str(p) for p in marking_points))
-                        
+                        signature_parts.append(
+                            "Answer Points: "
+                            + " | ".join(str(p) for p in marking_points)
+                        )
+
             return " | ".join(signature_parts)
         if question_type == QuestionType.LONG_ANSWER:
             description = str(payload.get("description", "")).strip()
@@ -1110,13 +1115,16 @@ class ExamGenerator:
                         if sub_prompt:
                             sub_prompts.append(sub_prompt)
             parts = [description, prompt] + sub_prompts
-            
+
             answer_data = payload.get("answer", {})
             if isinstance(answer_data, dict):
                 marking_points = answer_data.get("marking_points", [])
                 if isinstance(marking_points, list):
-                    parts.append("Expected Answer Points: " + " | ".join(str(p) for p in marking_points))
-                    
+                    parts.append(
+                        "Expected Answer Points: "
+                        + " | ".join(str(p) for p in marking_points)
+                    )
+
             return " | ".join(part for part in parts if part)
         return ""
 


### PR DESCRIPTION
Fixes #259 in which the ExamGenerator created very similar questions in different sections (e.g., an MCQ hinting at the answer to a subsequent short-answer question). By improving how we manage the LLM's context window, we make sure that each of the questions we generate is testing a different, non-overlapping concept.

->Updated the _question_signature method to not only record the question prompts, but also the generated answers and marking points.
->Injected CRITICAL prompt constraints which require the LLM to cross-reference its memory and explicitly stop concept repetition and leakage of answers.

[Old Paper.pdf](https://github.com/user-attachments/files/26689608/Old.Paper.pdf) - Shows the previous looping behaviour, cross-section answer leakage, and formatting glitches.

[New Paper.pdf](https://github.com/user-attachments/files/26689607/New.Paper.pdf) - Demonstrates the fix, distinct concepts across sections.

