### PR TITLE
fix: Temporarily Approve and Onboard New Users

### DIFF
--- a/app/services/state_service.py
+++ b/app/services/state_service.py
@@ -19,6 +19,9 @@ from app.monitoring.metrics import record_messages_generated
 
 
 class StateHandler:
+    # Temporary rollout toggle:
+    MANUAL_APPROVAL_REQUIRED = False
+
     def __init__(self):
         self.logger = logging.getLogger(__name__)
 
@@ -151,16 +154,24 @@ class StateHandler:
     async def handle_new_user_registration(
         self, phone_number: str, message_info: dict
     ) -> JSONResponse:
-        """Handle new users - create with in_review state (flow sent after admin approval)"""
+        """Handle new users and route to approval/onboarding according to rollout toggle."""
         try:
             from app.database.engine import get_session
             from app.config import settings, Environment
 
-            # Create a new user with in_review state (will remain in_review until approved by admin)
+            new_user_state = (
+                UserState.in_review
+                if self.MANUAL_APPROVAL_REQUIRED
+                else UserState.approved
+            )
+
+            # Create a new user in either:
+            # - in_review (legacy manual approval path), or
+            # - approved (auto-onboarding rollout path).
             new_user = User(
                 name=None,  # Will be filled during onboarding flow
                 wa_id=phone_number,
-                state=UserState.in_review,  # In review until approved
+                state=new_user_state,
                 onboarding_state=OnboardingState.new,  # Start with 'new' for normal onboarding flow
                 role=Role.teacher,
             )
@@ -178,6 +189,12 @@ class StateHandler:
                     f"Creating dummy user for {phone_number} in {settings.environment} environment"
                 )
                 return await self.handle_new_dummy(new_user)
+
+            if not self.MANUAL_APPROVAL_REQUIRED:
+                self.logger.info(
+                    "Manual approval bypass enabled. Starting onboarding for new user"
+                )
+                return await self.handle_new_approved_user(new_user)
 
             response_text = strings.get_string(
                 StringCategory.REGISTRATION, "registration_started"

--- a/tests/services/test_state_service.py
+++ b/tests/services/test_state_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi.responses import JSONResponse
 
 from app.config import Environment
 from app.database.enums import MessageRole, UserState
@@ -225,6 +226,7 @@ async def test_handle_new_user_registration_in_production_persists_visible_messa
     None
 ):
     service = StateHandler()
+    service.MANUAL_APPROVAL_REQUIRED = True
     session = AsyncMock()
     session.add = MagicMock()
     session.flush = AsyncMock()
@@ -260,6 +262,8 @@ async def test_handle_new_user_registration_in_production_persists_visible_messa
         )
 
     assert response.status_code == 200
+    persisted_user = session.add.call_args.args[0]
+    assert persisted_user.state == UserState.in_review
     mock_send_message.assert_awaited_once_with("255700000006", "Registration started")
     assert mock_create_message_by_fields.await_args.kwargs == {
         "user_id": 501,
@@ -267,3 +271,56 @@ async def test_handle_new_user_registration_in_production_persists_visible_messa
         "content": "Registration started",
         "is_present_in_conversation": True,
     }
+
+
+@pytest.mark.asyncio
+async def test_handle_new_user_registration_in_production_auto_onboards_when_manual_approval_disabled() -> (
+    None
+):
+    service = StateHandler()
+    service.MANUAL_APPROVAL_REQUIRED = False
+    expected_response = JSONResponse(content={"status": "ok"}, status_code=200)
+
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+
+    async def _refresh_user(user: User) -> None:
+        user.id = 502
+
+    session.refresh = AsyncMock(side_effect=_refresh_user)
+
+    with (
+        patch(
+            "app.database.engine.get_session",
+            return_value=_SessionContext(session),
+        ),
+        patch("app.config.settings.environment", Environment.PRODUCTION),
+        patch.object(
+            service,
+            "handle_new_approved_user",
+            AsyncMock(return_value=expected_response),
+        ) as mock_handle_new_approved_user,
+        patch(
+            "app.services.state_service.whatsapp_client.send_message",
+            AsyncMock(),
+        ) as mock_send_message,
+        patch(
+            "app.services.state_service.db.create_new_message_by_fields",
+            AsyncMock(),
+        ) as mock_create_message_by_fields,
+    ):
+        response = await service.handle_new_user_registration(
+            phone_number="255700000007",
+            message_info={"extracted_content": "Hi"},
+        )
+
+    assert response is expected_response
+    persisted_user = session.add.call_args.args[0]
+    assert persisted_user.state == UserState.approved
+    approved_user = mock_handle_new_approved_user.await_args.args[0]
+    assert approved_user.id == 502
+    assert approved_user.state == UserState.approved
+    mock_send_message.assert_not_awaited()
+    mock_create_message_by_fields.assert_not_awaited()


### PR DESCRIPTION
Temporarily bypass manual approval for new WhatsApp users during rollout.

**Changes**
- Added StateHandler.MANUAL_APPROVAL_REQUIRED toggle (default False).
- Updated handle_new_user_registration so, when toggle is off, new users are created as approved and immediately routed to handle_new_approved_user (welcome template + onboarding flow).
- Kept legacy manual flow intact behind the toggle (True => in_review + pending approval path).
- Added tests for both behaviors in tests/services/test_state_service.py.

**Validation**
- uv run pytest tests/services/test_state_service.py tests/services/test_request_service.py  tests/services/test_onboarding_service.py -q