### PR TITLE
fix: add subject-aware filtering to search_knowledge

### DIFF
--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -43,6 +43,10 @@ TOOLS_METADATA = [
                         "type": "integer",
                         "description": "The class id of the course the question should be based on. Available class IDs: {available_class_ids}",
                     },
+                    "subject": {
+                        "type": "string",
+                        "description": "Optional subject name to restrict retrieval to the matching subject resources for this form, for example 'chemistry'.",
+                    },
                 },
                 "required": ["search_phrase", "class_id"],
             },

--- a/app/tools/tool_code/search_knowledge/main.py
+++ b/app/tools/tool_code/search_knowledge/main.py
@@ -12,10 +12,41 @@ logger = logging.getLogger(__name__)
 async def search_knowledge(
     search_phrase: str,
     class_id: int,
+    subject: str | None = None,
 ) -> str:
     try:
+        target_class_id = class_id
+
+        if subject:
+            normalized_subject = subject.strip().lower().replace(" ", "_")
+            class_records = await db.read_classes([class_id])
+            base_class = class_records[0] if class_records else None
+
+            if normalized_subject and base_class:
+                subject_record = await db.read_subject_by_name(normalized_subject)
+                if subject_record:
+                    subject_class = await db.read_class_by_subject_id_grade_level_and_status(
+                        subject_id=subject_record.id,
+                        grade_level=base_class.grade_level.value,
+                        status=base_class.status.value,
+                    )
+                    if subject_class:
+                        target_class_id = subject_class.id
+                    else:
+                        logger.warning(
+                            "No class found for subject=%s and class_id=%s, falling back to class_id",
+                            normalized_subject,
+                            class_id,
+                        )
+                else:
+                    logger.warning(
+                        "Unknown subject=%s for search_knowledge, falling back to class_id=%s",
+                        normalized_subject,
+                        class_id,
+                    )
+
         # Retrieve the resources for the class
-        resource_ids = await db.get_class_resources(class_id)
+        resource_ids = await db.get_class_resources(target_class_id)
         assert resource_ids
 
         # Retrieve the relevant content

--- a/tests/tools/test_search_knowledge.py
+++ b/tests/tools/test_search_knowledge.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.database.enums import ChunkType, GradeLevel, SubjectClassStatus
+from app.tools.registry import TOOLS_METADATA
+
+
+@pytest.mark.asyncio
+@patch("app.tools.tool_code.search_knowledge.main.vector_search", new_callable=AsyncMock)
+@patch("app.tools.tool_code.search_knowledge.main.db.get_class_resources", new_callable=AsyncMock)
+@patch(
+    "app.tools.tool_code.search_knowledge.main.db.read_class_by_subject_id_grade_level_and_status",
+    new_callable=AsyncMock,
+)
+@patch("app.tools.tool_code.search_knowledge.main.db.read_subject_by_name", new_callable=AsyncMock)
+@patch("app.tools.tool_code.search_knowledge.main.db.read_classes", new_callable=AsyncMock)
+async def test_search_knowledge_uses_subject_specific_class_when_available(
+    mock_read_classes,
+    mock_read_subject_by_name,
+    mock_read_class_by_subject,
+    mock_get_class_resources,
+    mock_vector_search,
+):
+    from app.tools.tool_code.search_knowledge.main import search_knowledge
+
+    mock_read_classes.return_value = [
+        SimpleNamespace(
+            grade_level=GradeLevel.os2,
+            status=SubjectClassStatus.active,
+        )
+    ]
+    mock_read_subject_by_name.return_value = SimpleNamespace(id=7)
+    mock_read_class_by_subject.return_value = SimpleNamespace(id=42)
+    mock_get_class_resources.return_value = [99]
+    mock_vector_search.return_value = [
+        SimpleNamespace(
+            chunk_type=ChunkType.text,
+            top_level_section_title="Atoms",
+            resource_id=99,
+            content="Matter is made of atoms.",
+        )
+    ]
+
+    result = await search_knowledge(
+        search_phrase="Explain atoms",
+        class_id=5,
+        subject="Chemistry",
+    )
+
+    mock_read_classes.assert_awaited_once_with([5])
+    mock_read_subject_by_name.assert_awaited_once_with("chemistry")
+    mock_read_class_by_subject.assert_awaited_once_with(
+        subject_id=7,
+        grade_level="os2",
+        status="active",
+    )
+    mock_get_class_resources.assert_awaited_once_with(42)
+    assert "Matter is made of atoms." in result
+
+
+@pytest.mark.asyncio
+@patch("app.tools.tool_code.search_knowledge.main.vector_search", new_callable=AsyncMock)
+@patch("app.tools.tool_code.search_knowledge.main.db.get_class_resources", new_callable=AsyncMock)
+@patch(
+    "app.tools.tool_code.search_knowledge.main.db.read_class_by_subject_id_grade_level_and_status",
+    new_callable=AsyncMock,
+)
+@patch("app.tools.tool_code.search_knowledge.main.db.read_subject_by_name", new_callable=AsyncMock)
+@patch("app.tools.tool_code.search_knowledge.main.db.read_classes", new_callable=AsyncMock)
+async def test_search_knowledge_falls_back_to_given_class_without_subject(
+    mock_read_classes,
+    mock_read_subject_by_name,
+    mock_read_class_by_subject,
+    mock_get_class_resources,
+    mock_vector_search,
+):
+    from app.tools.tool_code.search_knowledge.main import search_knowledge
+
+    mock_get_class_resources.return_value = [5]
+    mock_vector_search.return_value = [
+        SimpleNamespace(
+            chunk_type=ChunkType.text,
+            top_level_section_title=None,
+            resource_id=5,
+            content="Fallback content",
+        )
+    ]
+
+    result = await search_knowledge(search_phrase="Explain weather", class_id=3)
+
+    mock_read_classes.assert_not_called()
+    mock_read_subject_by_name.assert_not_called()
+    mock_read_class_by_subject.assert_not_called()
+    mock_get_class_resources.assert_awaited_once_with(3)
+    assert "Fallback content" in result
+
+
+def test_search_knowledge_metadata_accepts_optional_subject():
+    search_tool = next(
+        tool for tool in TOOLS_METADATA if tool["function"]["name"] == "search_knowledge"
+    )
+
+    parameters = search_tool["function"]["parameters"]
+
+    assert "subject" in parameters["properties"]
+    assert parameters["required"] == ["search_phrase", "class_id"]


### PR DESCRIPTION
Fixes #255

## Summary
- add an optional `subject` parameter to the `search_knowledge` tool metadata
- resolve the subject-specific class for the same form before fetching resources
- add focused tests for subject-aware lookup and fallback behavior

## Testing
- META_API_VERSION=v1 META_APP_ID=test META_APP_SECRET=test WHATSAPP_CLOUD_NUMBER_ID=test WHATSAPP_VERIFY_TOKEN=test WHATSAPP_API_TOKEN=test DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/twiga uv run pytest tests/tools/test_search_knowledge.py