### PR TITLE
fix: persist page numbers for citations

### DIFF
--- a/scripts/database/resource_ingestion.py
+++ b/scripts/database/resource_ingestion.py
@@ -201,6 +201,7 @@ async def process_chunks(
                     resource_id=resource_id,
                     content=item.content,
                     chunk_type=ChunkType.text,  # TODO: include in json
+                    page_number=item.page_number,
                     top_level_section_index=str(item.chapter_number),
                     top_level_section_title=title[:100] if title else None,
                     embedding=item.embedding,


### PR DESCRIPTION
## Summary
- persist `page_number` when ingesting chunks into the database
- leave existing citation service fallback behavior unchanged

## Why
This makes chunk ingestion preserve page metadata so the existing citation service can use page-based citations when page numbers are available.

## Notes
- existing production data would still need re-ingestion/backfill to populate `page_number` for already-ingested chunks

## Testing
- pre-commit hooks passed during commit
- no additional application tests were run