### PR TITLE
Fix/multiple messages error

### DIFF
--- a/app/clients/agent_client.py
+++ b/app/clients/agent_client.py
@@ -1,10 +1,13 @@
 import json
 import logging
-from typing import Optional
 
 from langchain_core.messages import AIMessage
 
-from app.clients.client_base import ClientBase
+from app.clients.client_base import (
+    BUFFERED_RESPONSE,
+    ClientBase,
+    GenerateResponseResult,
+)
 from app.config import Prompt, llm_settings
 from app.database.models import Message, User
 from app.utils.llm_utils import async_llm_request
@@ -124,7 +127,7 @@ class AgentClient(ClientBase):
         self,
         user: User,
         message: Message,
-    ) -> Optional[list[Message]]:
+    ) -> GenerateResponseResult:
         """Generates a response using an agentic loop."""
         if user.id is None:
             self.logger.error("User object is missing an ID, cannot generate response.")
@@ -139,7 +142,7 @@ class AgentClient(ClientBase):
 
         if processor.is_locked:
             self.logger.info(f"Lock held for user {user.id}, message buffered")
-            return None
+            return BUFFERED_RESPONSE
 
         async with processor.lock:
             while True:

--- a/app/clients/agent_client.py
+++ b/app/clients/agent_client.py
@@ -145,8 +145,8 @@ class AgentClient(ClientBase):
             return BUFFERED_RESPONSE
 
         async with processor.lock:
-            while True:
-                try:
+            try:
+                while True:
                     api_messages, error_messages = await self._preprocess_messages(
                         user=user,
                         processor=processor,
@@ -213,7 +213,9 @@ class AgentClient(ClientBase):
                         final_messages.append(final_message)
 
                     if self._check_new_messages(processor, original_count):
-                        self.logger.warning("New messages buffered during processing")
+                        self.logger.info(
+                            "New messages buffered during processing. Discarding response and reprocessing batch."
+                        )
                         continue
 
                     # the last message in final messages is always an assistant message (either from normal
@@ -224,16 +226,14 @@ class AgentClient(ClientBase):
                         )
 
                     return final_messages
-                except Exception as e:
-                    self.logger.error(f"Error processing messages in agent loop: {e}")
-                    return None
-                finally:
-                    # This always runs, whether we returned above or an exception occurred.
-                    self.logger.debug(
-                        "Clearing message buffer and cleaning up processor"
-                    )
-                    processor.clear_messages()
-                    self._cleanup_processor(user.id)
+            except Exception as e:
+                self.logger.error(f"Error processing messages in agent loop: {e}")
+                return None
+            finally:
+                # This always runs, whether we returned above or an exception occurred.
+                self.logger.debug("Clearing message buffer and cleaning up processor")
+                processor.clear_messages()
+                self._cleanup_processor(user.id)
 
 
 agent_client = AgentClient()

--- a/app/clients/client_base.py
+++ b/app/clients/client_base.py
@@ -1,5 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Optional
 
 from langchain_core.messages import (
@@ -19,6 +20,18 @@ from app.tools.tool_manager import ToolManager
 from app.utils.message_processor import MessageProcessor
 from app.utils.prompt_manager import prompt_manager
 from app.utils.string_manager import StringCategory, strings
+
+
+@dataclass(frozen=True)
+class BufferedResponse:
+    """Generation was skipped because another request is already processing this user."""
+
+    reason: str = "message_buffered"
+
+
+BUFFERED_RESPONSE = BufferedResponse()
+
+GenerateResponseResult = list[Message] | BufferedResponse | None
 
 
 class ClientBase(ABC):
@@ -292,6 +305,6 @@ class ClientBase(ABC):
         self,
         user: User,
         message: Message,
-    ) -> Optional[list[Message]]:
+    ) -> GenerateResponseResult:
         """Generate a response, handling message batching and tool calls."""
         pass

--- a/app/clients/llm_client.py
+++ b/app/clients/llm_client.py
@@ -1,10 +1,13 @@
 import json
 import uuid
-from typing import Optional
 
 from langchain_core.messages import AIMessage, HumanMessage
 
-from app.clients.client_base import ClientBase
+from app.clients.client_base import (
+    BUFFERED_RESPONSE,
+    ClientBase,
+    GenerateResponseResult,
+)
 from app.config import LLMProvider, Prompt, llm_settings
 from app.database.models import Message, User
 from app.utils.llm_utils import async_llm_request
@@ -65,7 +68,7 @@ class LLMClient(ClientBase):
         self,
         user: User,
         message: Message,
-    ) -> Optional[list[Message]]:
+    ) -> GenerateResponseResult:
         """Generate a response, handling message batching and tool calls."""
         if user.id is None:
             self.logger.error("User object is missing an ID, cannot generate response.")
@@ -80,7 +83,7 @@ class LLMClient(ClientBase):
 
         if processor.is_locked:
             self.logger.info(f"Lock held for user {user.id}, message buffered")
-            return None
+            return BUFFERED_RESPONSE
 
         async with processor.lock:
             while True:

--- a/app/clients/llm_client.py
+++ b/app/clients/llm_client.py
@@ -86,8 +86,8 @@ class LLMClient(ClientBase):
             return BUFFERED_RESPONSE
 
         async with processor.lock:
-            while True:
-                try:
+            try:
+                while True:
                     # Preprocess messages: validate and build API messages
                     api_messages, error_messages = await self._preprocess_messages(
                         user=user,
@@ -214,16 +214,14 @@ class LLMClient(ClientBase):
                     self.logger.debug(f"New messages: {new_messages}")
                     return new_messages
 
-                except Exception as e:
-                    self.logger.error(f"Error processing messages: {e}")
-                    return None
-                finally:
-                    # This always runs, whether we returned above or an exception occurred.
-                    self.logger.debug(
-                        "Clearing message buffer and cleaning up processor"
-                    )
-                    processor.clear_messages()
-                    self._cleanup_processor(user.id)
+            except Exception as e:
+                self.logger.error(f"Error processing messages: {e}")
+                return None
+            finally:
+                # This always runs, whether we returned above or an exception occurred.
+                self.logger.debug("Clearing message buffer and cleaning up processor")
+                processor.clear_messages()
+                self._cleanup_processor(user.id)
 
 
 llm_client = LLMClient()

--- a/app/services/messaging_service.py
+++ b/app/services/messaging_service.py
@@ -7,7 +7,7 @@ import app.database.db as db
 import app.database.enums as enums
 import app.database.models as models
 from app.clients.agent_client import agent_client
-from app.clients.client_base import ClientBase
+from app.clients.client_base import BUFFERED_RESPONSE, ClientBase
 from app.clients.llm_client import llm_client
 from app.clients.whatsapp_client import DocumentType, ImageType, whatsapp_client
 from app.config import llm_settings
@@ -109,6 +109,9 @@ class MessagingService:
         llm_responses = await llm_client.generate_response(
             user=user, message=user_message
         )
+
+        if llm_responses is BUFFERED_RESPONSE:
+            return JSONResponse(content={"status": "ok"}, status_code=200)
 
         if not llm_responses:
             await self._handle_no_llm_response(user)

--- a/tests/clients/test_agent_client.py
+++ b/tests/clients/test_agent_client.py
@@ -1,0 +1,36 @@
+import pytest
+
+from app.clients.agent_client import AgentClient
+from app.clients.client_base import BUFFERED_RESPONSE
+from app.database.enums import MessageRole
+from app.database.models import Message, User
+
+
+def _make_user() -> User:
+    return User(id=1, name="Test User", wa_id="255700000001")
+
+
+def _make_user_message(content: str) -> Message:
+    return Message(user_id=1, role=MessageRole.user, content=content)
+
+
+@pytest.mark.asyncio
+async def test_generate_response_returns_buffered_when_processor_is_locked() -> None:
+    agent_client = AgentClient()
+    user = _make_user()
+    incoming_message = _make_user_message("second quick message")
+
+    processor = agent_client._get_processor(user.id)
+    await processor.lock.acquire()
+
+    try:
+        response = await agent_client.generate_response(
+            user=user,
+            message=incoming_message,
+        )
+    finally:
+        processor.lock.release()
+        processor.clear_messages()
+        agent_client._cleanup_processor(user.id)
+
+    assert response is BUFFERED_RESPONSE

--- a/tests/clients/test_llm_client.py
+++ b/tests/clients/test_llm_client.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 
+from app.clients.client_base import BUFFERED_RESPONSE
 from app.clients.llm_client import LLMClient, _prepare_message_for_together
 from app.config import Prompt
 from app.database.enums import MessageRole
@@ -105,6 +106,28 @@ async def test_generate_response_requires_user_id() -> None:
             user=user,
             message=_make_user_message("hello"),
         )
+
+
+@pytest.mark.asyncio
+async def test_generate_response_returns_buffered_when_processor_is_locked() -> None:
+    llm_client = LLMClient()
+    user = _make_user()
+    incoming_message = _make_user_message("second quick message")
+
+    processor = llm_client._get_processor(user.id)
+    await processor.lock.acquire()
+
+    try:
+        response = await llm_client.generate_response(
+            user=user,
+            message=incoming_message,
+        )
+    finally:
+        processor.lock.release()
+        processor.clear_messages()
+        llm_client._cleanup_processor(user.id)
+
+    assert response is BUFFERED_RESPONSE
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_messaging_service.py
+++ b/tests/services/test_messaging_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 import app.database.enums as enums
+from app.clients.client_base import BUFFERED_RESPONSE
 from app.database.models import Message, User
 from app.services.citation_service import CitationRenderResult
 from app.services.exam_delivery_service import ExamPDFDeliveryDetails
@@ -142,6 +143,52 @@ async def test_handle_chat_message_persists_general_error_when_llm_returns_none(
         "is_present_in_conversation": True,
         "source_chunk_ids": None,
     }
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_message_does_not_send_error_when_message_is_buffered() -> (
+    None
+):
+    service = MessagingService()
+    user = User(id=3, wa_id="255700000000", name="Teacher")
+    user_message = Message(
+        user_id=3,
+        role=enums.MessageRole.user,
+        content="Second quick message",
+    )
+
+    with (
+        patch("app.services.messaging_service.llm_settings.agentic_mode", False),
+        patch(
+            "app.services.messaging_service.llm_client.generate_response",
+            AsyncMock(return_value=BUFFERED_RESPONSE),
+        ),
+        patch(
+            "app.services.messaging_service.strings.get_string",
+            return_value="Something went wrong.",
+        ) as mock_get_string,
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_message",
+            AsyncMock(),
+        ) as mock_send_message,
+        patch(
+            "app.services.messaging_service.db.create_new_message_by_fields",
+            AsyncMock(),
+        ) as mock_create_message_by_fields,
+        patch(
+            "app.services.messaging_service.record_messages_generated"
+        ) as mock_record_messages_generated,
+    ):
+        response = await service.handle_chat_message(
+            user=user,
+            user_message=user_message,
+        )
+
+    assert response.status_code == 200
+    mock_get_string.assert_not_called()
+    mock_send_message.assert_not_awaited()
+    mock_create_message_by_fields.assert_not_awaited()
+    mock_record_messages_generated.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR fixes the concurrency bug in #313.

**Problem**

When a user sent multiple whatsapp messages quickly, the second request entered `generate_response()` while the first one was still processing.

The message was added to the processor buffer, but `generate_response()` returned `None`. Then `handle_chat_message()` interpreted that `None` as an LLM failure and sent the generic error message. This caused the first wrong error reply.

There was also a second issue in `generate_response()`: when the first request detected that a new message had arrived, it used `continue` to restart the loop with the updated messages. However, the `finally` block still ran and cleared the processor buffer before the next loop iteration. That made the next iteration start with no messages, causing the second generic error reply.

**Solution**

For the first error message, it has been added a new `BufferedResponse` return type, with `BUFFERED_RESPONSE`, to separate the “message was buffered” case from the “LLM failed” case.

Now, when a request arrives while another request is already processing the same user, `generate_response()` returns `BUFFERED_RESPONSE` instead of `None`. `handle_chat_message()` treats this as "do nothing" and returns `200 OK` without sending or persisting an error message.

For the second error message, the response-generation loop has been refactored so the processor buffer is not cleared when the loop intentionally restarts after detecting new messages.

Finally, there has been the minimal unit tests for the new buffered-response path.

**To do**
The mock-whatsapp channel still needs to be updated to make sure these concurrency bugs are caught much earlier by the developers. 