### PR TITLE
refactor: make search_knowledge resulting chunks configurable

### DIFF
--- a/app/assets/config/base.yml
+++ b/app/assets/config/base.yml
@@ -42,6 +42,9 @@ embedding:
     request_timeout: 30
 
 tools:
+  search_knowledge:
+    n_results: 15
+
   solve_equation:
     model_name: "MiniMaxAI/MiniMax-M3"
     provider: together

--- a/app/config.py
+++ b/app/config.py
@@ -242,6 +242,10 @@ class ToolSettings(BaseSettings):
         env_prefix="TOOL_",
     )
 
+    search_knowledge_n_results: int = yaml_config["tools"]["search_knowledge"][
+        "n_results"
+    ]
+
     solve_equation_api_key: Optional[SecretStr] = Field(
         default=None, validation_alias="llm_api_key"
     )

--- a/app/tools/tool_code/search_knowledge/main.py
+++ b/app/tools/tool_code/search_knowledge/main.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional, TypedDict
 
 import app.database.db as db
+from app.config import tool_settings
 from app.database.db import vector_search
 from app.database.enums import ChunkType
 from app.database.models import Chunk, Resource
@@ -26,7 +27,7 @@ async def search_knowledge(
         # Retrieve the relevant content
         retrieved_content = await vector_search(
             query=search_phrase,
-            n_results=15,
+            n_results=tool_settings.search_knowledge_n_results,
             where={
                 "chunk_type": [ChunkType.text],
                 "resource_id": resource_ids,


### PR DESCRIPTION
Previously, the number of chunks retrieved by `search_knowledge()` was hardcoded in the application code. Now it follows the same pattern as other tools by using `base.yml`.