### PR TITLE
Hotfix/whatsapp length limit

### DIFF
--- a/app/clients/whatsapp_client.py
+++ b/app/clients/whatsapp_client.py
@@ -21,6 +21,7 @@ from app.utils.whatsapp_utils import (
     generate_payload,
     generate_payload_for_document,
     generate_payload_for_image,
+    split_text_for_whatsapp,
 )
 
 
@@ -44,6 +45,7 @@ def _extract_statuses(body: dict) -> list[dict]:
 class WhatsAppClient:
     _MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
     _MAX_DOCUMENT_SIZE_BYTES = 100 * 1024 * 1024  # 100 MB
+    _MAX_TEXT_LENGTH_CHARS = 4096
 
     def __init__(self):
         self.headers = {
@@ -56,20 +58,47 @@ class WhatsAppClient:
 
     async def send_message(
         self, wa_id: str, message: str, options: list[str] | None = None
-    ) -> None:
+    ) -> bool:
         if settings.mock_whatsapp:
-            return
+            return True
 
+        i, total = 0, 0
         try:
-            payload: dict[str, Any] = generate_payload(wa_id, message, options)
-            response = await self.client.post(
-                "/messages", data=payload, headers=self.headers
+            # Margin: Meta may count emoji as 2 chars (UTF-16 units)
+            safe_limit = self._MAX_TEXT_LENGTH_CHARS - 96
+            chunks: list[str] = split_text_for_whatsapp(message, max_length=safe_limit)
+            total = len(chunks)
+
+            for i, chunk in enumerate(chunks, start=1):
+                payload: dict[str, Any] = generate_payload(
+                    wa_id, chunk, options if i == total else None
+                )
+                response = await self.client.post(
+                    "/messages", data=payload, headers=self.headers
+                )
+
+                log_httpx_response(response)
+                response.raise_for_status()
+
+            return True
+
+        except httpx.HTTPStatusError as e:
+            self.logger.error(
+                f"WhatsApp rejected message for {wa_id} (chunk {i}/{total}, "
+                f"status {e.response.status_code}): {e.response.text}"
             )
-            log_httpx_response(response)
+            record_whatsapp_event(f"send_failed:{e.response.status_code}")
         except httpx.RequestError as e:
-            self.logger.error(f"Request Error: {e}")
+            self.logger.error(
+                f"WhatsApp request error for {wa_id} (chunk {i}/{total}): {e}"
+            )
+            record_whatsapp_event("send_failed:request_error")
         except Exception as e:
-            self.logger.error(f"Unexpected Error: {e}")
+            self.logger.error(
+                f"Unexpected error sending to {wa_id} (chunk {i}/{total}): {e}"
+            )
+            record_whatsapp_event("send_failed:unexpected")
+        return False
 
     async def send_read_receipt_with_typing_indicator(self, message_id: str) -> None:
         """

--- a/app/services/messaging_service.py
+++ b/app/services/messaging_service.py
@@ -159,8 +159,9 @@ class MessagingService:
             source_chunk_ids=last_assistant_message.source_chunk_ids,
         )
 
-        await whatsapp_client.send_message(user.wa_id, llm_content)
-        record_messages_generated("chat_response")
+        sent = await whatsapp_client.send_message(user.wa_id, llm_content)
+        if sent:
+            record_messages_generated("chat_response")
 
         return JSONResponse(content={"status": "ok"}, status_code=200)
 

--- a/app/utils/whatsapp_utils.py
+++ b/app/utils/whatsapp_utils.py
@@ -378,3 +378,44 @@ def get_request_type(body: dict) -> RequestType:
         raise
 
     return RequestType.VALID_MESSAGE
+
+
+def split_text_for_whatsapp(message: str, max_length: int) -> list[str]:
+    messages = []
+    remaining = message
+
+    while remaining:
+        valid_chunk, remaining = _split_text(remaining, max_length)
+        messages.append(valid_chunk)
+
+    # Return only non-empty chunks
+    return [chunk for chunk in messages if chunk.strip()]
+
+
+_MIN_FILL_RATIO = 0.6
+
+
+def _split_text(text: str, max_length: int) -> tuple[str, str]:
+    """
+    Splits text into (first_chunk, remainder) where len(first_chunk) <= max_length.
+
+    Fallback priority:
+      1. Paragraph boundary ('\\n\\n')
+      2. Line boundary ('\\n')
+      3. Sentence boundary ('. ')
+      4. Hard cut (max_length)
+    """
+    if len(text) <= max_length:
+        return text, ""
+
+    candidate = text[:max_length]
+    floor = int(max_length * _MIN_FILL_RATIO)
+
+    # (separator, chars of the separator to keep on the left side)
+    for separator, keep in (("\n\n", 0), ("\n", 0), (". ", 1)):
+        idx = candidate.rfind(separator)
+        if idx >= floor:
+            cut = idx + keep
+            return text[:cut].rstrip(), text[cut:].lstrip()
+
+    return text[:max_length], text[max_length:]

--- a/tests/utils/test_whatsapp_utils.py
+++ b/tests/utils/test_whatsapp_utils.py
@@ -1,0 +1,151 @@
+"""Tests for splitting outbound text to fit WhatsApp's message length limit."""
+
+from app.utils.whatsapp_utils import split_text_for_whatsapp
+
+# Meta's documented limit for a text message body.
+WHATSAPP_TEXT_LIMIT = 4096
+
+# Small limit keeps the fixtures readable; the logic is independent of scale.
+LIMIT = 100
+
+
+def _visible(text: str) -> str:
+    """Text with all whitespace removed, for comparing content across chunks."""
+    return "".join(text.split())
+
+
+def test_short_message_is_returned_unchanged() -> None:
+    message = "Here is your lesson plan."
+
+    assert split_text_for_whatsapp(message, LIMIT) == [message]
+
+
+def test_message_exactly_at_limit_is_not_split() -> None:
+    message = "a" * LIMIT
+
+    assert split_text_for_whatsapp(message, LIMIT) == [message]
+
+
+def test_message_one_char_over_limit_is_split() -> None:
+    chunks = split_text_for_whatsapp("a" * (LIMIT + 1), LIMIT)
+
+    assert len(chunks) == 2
+    assert [len(chunk) for chunk in chunks] == [LIMIT, 1]
+
+
+def test_empty_message_produces_no_chunks() -> None:
+    assert split_text_for_whatsapp("", LIMIT) == []
+
+
+def test_whitespace_only_message_produces_no_chunks() -> None:
+    """Empty bodies are rejected by WhatsApp, so they must never be sent."""
+    assert split_text_for_whatsapp("   \n\n  \t ", LIMIT) == []
+
+
+def test_no_chunk_ever_exceeds_the_limit() -> None:
+    """The invariant the whole function exists to guarantee."""
+    messages = [
+        "a" * 10_000,  # one long word, no separator anywhere
+        ("word " * 2_000),
+        ("Paragraph body here.\n\n" * 200),
+        "\n".join("Line number %d" % i for i in range(500)),
+        "Sentence one. Sentence two. " * 300,
+    ]
+
+    for message in messages:
+        for chunk in split_text_for_whatsapp(message, LIMIT):
+            assert len(chunk) <= LIMIT
+
+
+def test_splitting_preserves_all_content() -> None:
+    """Splitting may drop separator whitespace, but never visible characters."""
+    message = (
+        "Lesson Plan: Solving Linear Equations\n\n"
+        + "Learning objectives. " * 50
+        + "\n\n"
+        + "Homework. " * 80
+    )
+
+    chunks = split_text_for_whatsapp(message, LIMIT)
+
+    assert _visible("".join(chunks)) == _visible(message)
+
+
+def test_prefers_paragraph_boundary() -> None:
+    message = "A" * 70 + "\n\n" + "B" * 70
+
+    assert split_text_for_whatsapp(message, LIMIT) == ["A" * 70, "B" * 70]
+
+
+def test_falls_back_to_line_boundary_when_no_paragraph_break() -> None:
+    message = "A" * 70 + "\n" + "B" * 70
+
+    assert split_text_for_whatsapp(message, LIMIT) == ["A" * 70, "B" * 70]
+
+
+def test_falls_back_to_sentence_boundary_and_keeps_the_period() -> None:
+    message = "A" * 68 + ". " + "B" * 70
+
+    assert split_text_for_whatsapp(message, LIMIT) == ["A" * 68 + ".", "B" * 70]
+
+
+def test_hard_cuts_when_no_separator_exists() -> None:
+    chunks = split_text_for_whatsapp("a" * 250, LIMIT)
+
+    assert chunks == ["a" * 100, "a" * 100, "a" * 50]
+
+
+def test_ignores_boundary_that_would_leave_a_tiny_chunk() -> None:
+    """
+    A paragraph break near the start is below the minimum-fill floor. Using it
+    would emit a 5-character message and waste a chunk, so the split falls
+    through to a fuller cut instead.
+    """
+    message = "A" * 5 + "\n\n" + "B" * 300
+
+    chunks = split_text_for_whatsapp(message, LIMIT)
+
+    assert len(chunks[0]) > LIMIT // 2
+
+
+def test_leading_whitespace_does_not_produce_an_empty_first_chunk() -> None:
+    chunks = split_text_for_whatsapp("   \n\n" + "B" * 300, LIMIT)
+
+    assert all(chunk.strip() for chunk in chunks)
+
+
+def test_trailing_newlines_do_not_produce_an_empty_last_chunk() -> None:
+    chunks = split_text_for_whatsapp("a" * 150 + "\n\n\n\n", LIMIT)
+
+    assert all(chunk.strip() for chunk in chunks)
+
+
+def test_lesson_plan_sized_message_fits_whatsapp_limit() -> None:
+    """
+    Regression test for the production bug: an ~8000 character lesson plan was
+    posted as a single body and rejected by Meta with
+    "(#100) Param text['body'] must be at most 4096 characters long."
+    """
+    lesson_plan = (
+        "Here is your lesson plan! \U0001f4d8\n\n"
+        "*Lesson Plan: Solving Linear Equations*\n"
+        "*Subject:* Mathematics\n\n"
+        + "*Learning Objectives:*\n"
+        + "".join(
+            f"{i}. Solve linear equations by applying inverse operations "
+            f"while maintaining balance on both sides.\n"
+            for i in range(1, 40)
+        )
+        + "\n*Homework:*\n"
+        + "".join(
+            f"- Exercise {i}: solve and verify by substitution.\n" for i in range(1, 40)
+        )
+    )
+    assert len(lesson_plan) > WHATSAPP_TEXT_LIMIT
+
+    chunks = split_text_for_whatsapp(lesson_plan, WHATSAPP_TEXT_LIMIT)
+
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert len(chunk) <= WHATSAPP_TEXT_LIMIT
+    assert _visible("".join(chunks)) == _visible(lesson_plan)


### PR DESCRIPTION
## Problem

Teachers requesting a lesson plan received the "📋 Creating a lesson plan, please hold..." notification and then **nothing at all**, with no error surfaced and no `ERROR` in the logs.

The lesson plan was generated correctly. It was rejected by Meta on delivery:

```
{"error":{"message":"(#100) Param text['body'] must be at most 4096 characters long.",
 "type":"OAuthException","code":100,"fbtrace_id":"A84XX8pl1Fw0rtXSO54A-eD"}}
```

A typical lesson plan is ~8000 characters against WhatsApp's 4096-character limit for text bodies.

It went unnoticed because httpx does not raise on 4xx and `send_message` never called `raise_for_status()`, so the `400` returned as a normal response and the caller carried on as if the send had succeeded. The only trace was a `WARNING` from `log_httpx_response` with no `wa_id` or message context, so grepping for `lesson`, `plan`, or `error` found nothing.

## Changes

**`split_text_for_whatsapp()`** (`app/utils/whatsapp_utils.py`) — new pure function that splits text into chunks under a given length, cutting at the latest paragraph, line, or sentence boundary available, and hard-cutting only when none exists. Boundaries are ignored if they fall below 60% of the budget, which prevents stub messages and bounds the total chunk count.

**`send_message()`** (`app/clients/whatsapp_client.py`) — splits the body and sends one message per chunk, and now reports failures instead of swallowing them:

- `raise_for_status()` per chunk, so the first failure aborts the rest.
- Failures logged at **ERROR** with `wa_id`, chunk index, and status code, plus a `record_whatsapp_event("send_failed:...")` counter so delivery failures are visible in Grafana.
- Returns `bool`. Existing callers that ignore it are unaffected.
- Splits slightly below 4096 to absorb ambiguity in how Meta counts emoji (code points vs UTF-16 code units).

**`messaging_service.py`** — `record_messages_generated("chat_response")` is now gated on a successful send, so the metric stops counting undelivered messages.

## Not fixed here

Lesson plans containing LaTeX math take a **different** delivery path: `looks_like_latex()` matches a bare `$`, routing them to `_send_latex_response`, which uploads a PNG via `send_image_message` and bypasses this fix entirely. That path has its own pre-existing bug — only `pdf_document[0]` is rasterized, so multi-page plans arrive as a single truncated image.

Which path a plan takes depends on whether the model emits math delimiters for that generation. The production failures above were all on the text path.

Two other pre-existing issues surfaced while investigating, both out of scope:

- `create_lesson_plan` fails intermittently; `tool_manager` turns the exception into a tool message and the agent retries, which is why the "please hold" notification sometimes appears 2–3 times. Each one is a real attempt.
- `is_present_in_conversation` is written in 15 places and never read. `get_user_message_history` doesn't filter on it, so assistant replies persisted twice both land in the model's context.

## Verifying after deploy

`render logs -r srv-cudmog2j1k6c73cqabvg --text "must be at most 4096"` should return nothing.