### PR TITLE
fix: Duplicate assistant messages sent to LLM as chat history

### DIFF
--- a/app/database/db.py
+++ b/app/database/db.py
@@ -195,12 +195,16 @@ async def update_user(user: User) -> User:
 async def get_user_message_history(
     user_id: int, limit: int = 10
 ) -> list[Message] | None:
+    """Return the latest visible conversation messages in chronological order."""
     async with get_session() as session:
         try:
             # TODO: Make the database order this by default to reduce repeated operations
             statement = (
                 select(Message)
-                .where(Message.user_id == user_id)
+                .where(
+                    Message.user_id == user_id,
+                    Message.is_present_in_conversation.is_(True),
+                )
                 .order_by(desc(Message.created_at))
                 .limit(limit)
             )
@@ -208,7 +212,7 @@ async def get_user_message_history(
             result = await session.execute(statement)
             messages = result.scalars().all()
 
-            # If no messages found, return empty list
+            # If no visible messages are found, return None
             if not messages:
                 logger.debug(f"No message history found for user {user_id}")
                 return None

--- a/scripts/crons/approve_users_cron.py
+++ b/scripts/crons/approve_users_cron.py
@@ -103,6 +103,7 @@ async def approve_and_welcome_users() -> None:
                         user_id=user.id,
                         role=MessageRole.assistant,
                         content=f"Welcome template sent: {WELCOME_TEMPLATE_ID}",
+                        is_present_in_conversation=True,
                     )
                     await create_new_messages([welcome_db_message])
 

--- a/tests/clients/test_agent_client.py
+++ b/tests/clients/test_agent_client.py
@@ -1,9 +1,37 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
 import pytest
+from langchain_core.messages import AIMessage
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
 from app.clients.agent_client import AgentClient
 from app.clients.client_base import BUFFERED_RESPONSE
+from app.database import db
 from app.database.enums import MessageRole
 from app.database.models import Message, User
+
+
+@pytest.fixture
+def message_history_session(monkeypatch):
+    """Execute the real history query locally without a PostgreSQL connection."""
+    engine = create_engine("sqlite:///:memory:")
+    Message.__table__.create(engine)
+    try:
+        with Session(engine) as session:
+            async_session = AsyncMock()
+            async_session.execute.side_effect = session.execute
+
+            @asynccontextmanager
+            async def get_session():
+                yield async_session
+
+            monkeypatch.setattr(db, "get_session", get_session)
+            yield session
+    finally:
+        engine.dispose()
 
 
 def _make_user() -> User:
@@ -12,6 +40,69 @@ def _make_user() -> User:
 
 def _make_user_message(content: str) -> Message:
     return Message(user_id=1, role=MessageRole.user, content=content)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw_content", "visible_content"),
+    [
+        (
+            "An explanation. {{TWIGA_CITATION:123}}",
+            "An explanation. [1]\n\nSources:\n[1] Biology textbook",
+        ),
+        (
+            'Here is your exam. {{TWIGA_EXAM_DELIVERY:{"exam_id":"exam-1"}}}',
+            "Here is your exam.",
+        ),
+    ],
+)
+async def test_llm_request_contains_visible_assistant_response_without_raw_duplicate(
+    message_history_session, raw_content, visible_content
+) -> None:
+    client = AgentClient()
+    user = _make_user()
+    start = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    messages = [
+        Message(
+            user_id=user.id,
+            role=MessageRole.user,
+            content="Help me prepare a lesson.",
+            is_present_in_conversation=True,
+        ),
+        Message(user_id=user.id, role=MessageRole.assistant, content=raw_content),
+        Message(
+            user_id=user.id,
+            role=MessageRole.assistant,
+            content=visible_content,
+            is_present_in_conversation=True,
+        ),
+        Message(
+            user_id=user.id,
+            role=MessageRole.user,
+            content="Tell me more.",
+            is_present_in_conversation=True,
+        ),
+    ]
+    for index, message in enumerate(messages):
+        message.created_at = start + timedelta(seconds=index)
+    message_history_session.add_all(messages)
+    message_history_session.commit()
+
+    with patch(
+        "app.clients.agent_client.async_llm_request",
+        AsyncMock(return_value=AIMessage(content="More detail.")),
+    ) as mock_request:
+        response = await client.generate_response(user, messages[-1])
+
+    assert response is not None
+    mock_request.assert_awaited_once()
+    payload = mock_request.await_args.kwargs["messages"]
+    assert [(message.type, message.content) for message in payload[1:]] == [
+        ("human", "Help me prepare a lesson."),
+        ("ai", visible_content),
+        ("human", "Tell me more."),
+    ]
+    assert payload[0].type == "system"
 
 
 @pytest.mark.asyncio

--- a/tests/crons/test_approve_users_cron.py
+++ b/tests/crons/test_approve_users_cron.py
@@ -45,3 +45,4 @@ async def test_approve_users_persists_welcome_with_shared_message_writer() -> No
         and persisted_messages[0].user_id == user.id
         and "Welcome template sent" in persisted_messages[0].content
     )
+    assert persisted_messages[0].is_present_in_conversation is True

--- a/tests/database/test_db_message_helpers.py
+++ b/tests/database/test_db_message_helpers.py
@@ -1,9 +1,33 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
 from app.database import db, enums
 from app.database.models import Message
+
+
+@pytest.fixture
+def message_history_session(monkeypatch):
+    """Execute the real history query locally without a PostgreSQL connection."""
+    engine = create_engine("sqlite:///:memory:")
+    Message.__table__.create(engine)
+    try:
+        with Session(engine) as session:
+            async_session = AsyncMock()
+            async_session.execute.side_effect = session.execute
+
+            @asynccontextmanager
+            async def get_session():
+                yield async_session
+
+            monkeypatch.setattr(db, "get_session", get_session)
+            yield session
+    finally:
+        engine.dispose()
 
 
 class _SessionContext:
@@ -15,6 +39,67 @@ class _SessionContext:
 
     async def __aexit__(self, exc_type, exc, tb):
         return False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [1, 3, 10])
+async def test_history_limits_visible_messages_in_chronological_order(
+    message_history_session, limit
+) -> None:
+    start = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    visible_messages = []
+    for index in range(12):
+        visible = Message(
+            user_id=7,
+            role=enums.MessageRole.user
+            if index % 2 == 0
+            else enums.MessageRole.assistant,
+            content=f"Visible message {index}",
+            is_present_in_conversation=True,
+            created_at=start + timedelta(seconds=index * 2),
+        )
+        visible_messages.append(visible)
+        message_history_session.add_all(
+            [
+                visible,
+                Message(
+                    user_id=7,
+                    role=visible.role,
+                    content=f"Hidden message {index}",
+                    is_present_in_conversation=False,
+                    created_at=start + timedelta(seconds=index * 2 + 1),
+                ),
+            ]
+        )
+    message_history_session.add(
+        Message(
+            user_id=8,
+            role=enums.MessageRole.assistant,
+            content="Another user's visible message",
+            is_present_in_conversation=True,
+            created_at=start + timedelta(minutes=1),
+        )
+    )
+    message_history_session.commit()
+
+    history = await db.get_user_message_history(7, limit=limit)
+
+    assert [message.id for message in history] == [
+        message.id for message in visible_messages[-limit:]
+    ]
+    assert message_history_session.query(Message).count() == 25
+
+
+@pytest.mark.asyncio
+async def test_history_returns_none_when_only_hidden_messages_exist(
+    message_history_session,
+) -> None:
+    message_history_session.add(
+        Message(user_id=7, role=enums.MessageRole.assistant, content="Raw response")
+    )
+    message_history_session.commit()
+
+    assert await db.get_user_message_history(7) is None
 
 
 @pytest.mark.asyncio

--- a/tests/database/test_db_message_helpers.py
+++ b/tests/database/test_db_message_helpers.py
@@ -51,9 +51,11 @@ async def test_history_limits_visible_messages_in_chronological_order(
     for index in range(12):
         visible = Message(
             user_id=7,
-            role=enums.MessageRole.user
-            if index % 2 == 0
-            else enums.MessageRole.assistant,
+            role=(
+    enums.MessageRole.user
+    if index % 2 == 0
+    else enums.MessageRole.assistant
+),
             content=f"Visible message {index}",
             is_present_in_conversation=True,
             created_at=start + timedelta(seconds=index * 2),

--- a/tests/database/test_db_message_helpers.py
+++ b/tests/database/test_db_message_helpers.py
@@ -52,10 +52,10 @@ async def test_history_limits_visible_messages_in_chronological_order(
         visible = Message(
             user_id=7,
             role=(
-    enums.MessageRole.user
-    if index % 2 == 0
-    else enums.MessageRole.assistant
-),
+                enums.MessageRole.user
+                if index % 2 == 0
+                else enums.MessageRole.assistant
+            ),
             content=f"Visible message {index}",
             is_present_in_conversation=True,
             created_at=start + timedelta(seconds=index * 2),


### PR DESCRIPTION
<p>Assistant responses are saved as both raw LLM output and user-visible text. Previously, both copies were included in subsequent LLM requests, repeating answers and wasting slots in the 10-message history.</p><p>The fix filters history by <code dir="ltr">is_present_in_conversation=True</code> <strong>before applying the limit</strong>. Raw copies remain stored for debugging.</p><p>Actual outgoing request logs from September 7 show the difference:</p><div><div><div>
<html><head></head><body>

[logs.txt](https://github.com/user-attachments/files/31928045/example.txt)

<table>
<tr>
<th>Assistant response </th>
<th>Without fix, 20:19 UTC</th>
<th>With fix, 20:24 UTC </th>
</tr>
<tr>
<td>“Hello! 👋 Welcome to Twiga, your Geography teaching assistant…” </td>
<td>Twice </td>
<td>Once </td>
</tr>

<tr>
<td>“I couldn't create the lesson plan right now…” </td>
<td>Twice </td>
<td>Once </td>
</tr>

</table>

</body></html>

</div></div></div><p>A separate citation follow-up confirmed that only the rendered answer returned in history; its raw <code dir="ltr">TWIGA_CITATION</code> copy was excluded.</p><p>Files changed:</p><ul><li><strong><code dir="ltr">app/database/db.py</code></strong> — filters history to visible messages while preserving chronological order.</li><li><strong><code dir="ltr">tests/database/test_db_message_helpers.py</code></strong> — verifies filtering, limits, chronological order, user isolation, empty visible history, and preservation of stored rows.</li><li><strong><code dir="ltr">tests/clients/test_agent_client.py</code></strong> — verifies outgoing LLM requests contain only the visible answer for citation and exam-marker cases.</li></ul><p>Both test files include their own in-memory database fixture. No new files, dependencies, or migrations are required.</p><p>Validation: <strong>49 tests passed</strong>; Ruff lint, test-file formatting, and whitespace checks passed.</p>