### PR TITLE
fix: send every rendered LaTeX page as a WhatsApp image

### DIFF
--- a/app/latex/latex_artifact_generator.py
+++ b/app/latex/latex_artifact_generator.py
@@ -505,62 +505,69 @@ def compile_latex_to_pdf(latex_body: str, temp_dir: str) -> str:
     return pdf_path
 
 
-def text_to_img(content: str) -> str | None:
-    """
-    Convert a LaTeX document body to a PNG image. Returns the path to the PNG image.
-    """
+def text_to_images(content: str) -> list[str] | None:
+    """Convert every page of a LaTeX document body to a PNG image."""
     logger = logging.getLogger(__name__)
     temp_dir = tempfile.mkdtemp()
     output_dir = os.getcwd() if _should_persist_latex_image_locally() else None
     if output_dir is not None:
         os.makedirs(output_dir, exist_ok=True)
-    output_file_descriptor, output_path = tempfile.mkstemp(
-        prefix="twiga_latex_", suffix=".png", dir=output_dir
-    )
-    os.close(output_file_descriptor)
-    rendered_image_ready = False
+    output_paths: list[str] = []
+    rendered_images_ready = False
 
     try:
         pdf_path = compile_latex_to_pdf(content, temp_dir)
     except Exception as exc:
         logger.error("Error compiling LaTeX: %s", exc)
-        try:
-            os.remove(output_path)
-        except OSError:
-            pass
         shutil.rmtree(temp_dir, ignore_errors=True)
         return None
 
     try:
         pdf_document = fitz.open(pdf_path)
         try:
-            page = pdf_document[0]
-            for dpi in PDF_RENDER_DPI_CANDIDATES:
-                pix = page.get_pixmap(dpi=dpi)
-                pix.save(output_path)
-                if os.path.getsize(output_path) <= WHATSAPP_MAX_IMAGE_SIZE_BYTES:
-                    rendered_image_ready = True
-                    if output_dir is not None:
-                        logger.info(
-                            "Saved LaTeX image locally for debugging: %s",
-                            output_path,
-                        )
-                    return output_path
-            logger.warning(
-                "Generated image exceeds WhatsApp upload limit after DPI fallback (%s).",
-                output_path,
-            )
+            for page_number, page in enumerate(pdf_document, start=1):
+                output_file_descriptor, output_path = tempfile.mkstemp(
+                    prefix="twiga_latex_", suffix=".png", dir=output_dir
+                )
+                os.close(output_file_descriptor)
+                output_paths.append(output_path)
+
+                for dpi in PDF_RENDER_DPI_CANDIDATES:
+                    pix = page.get_pixmap(dpi=dpi)
+                    pix.save(output_path)
+                    if os.path.getsize(output_path) <= WHATSAPP_MAX_IMAGE_SIZE_BYTES:
+                        if output_dir is not None:
+                            logger.info(
+                                "Saved LaTeX image locally for debugging: %s",
+                                output_path,
+                            )
+                        break
+
+                else:
+                    logger.warning(
+                        "Generated LaTeX image for page %s exceeds WhatsApp upload "
+                        "limit after DPI fallback (%s).",
+                        page_number,
+                        output_path,
+                    )
+                    return None
+
+            if output_paths:
+                rendered_images_ready = True
+                return output_paths
+            return None
         finally:
             pdf_document.close()
     except Exception as exc:
-        logger.error("Error converting LaTeX PDF to image: %s", exc)
+        logger.error("Error converting LaTeX PDF to images: %s", exc)
         return None
     finally:
-        if not rendered_image_ready and os.path.exists(output_path):
-            try:
-                os.remove(output_path)
-            except OSError:
-                pass
+        if not rendered_images_ready:
+            for output_path in output_paths:
+                try:
+                    os.remove(output_path)
+                except OSError:
+                    pass
         shutil.rmtree(temp_dir, ignore_errors=True)
 
 

--- a/app/services/messaging_service.py
+++ b/app/services/messaging_service.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import Optional
 
 from fastapi.responses import JSONResponse
@@ -14,7 +15,7 @@ from app.config import llm_settings
 from app.latex.latex_artifact_generator import (
     looks_like_latex,
     prepare_latex_body,
-    text_to_img,
+    text_to_images,
 )
 from app.monitoring.metrics import record_messages_generated, track_messages
 from app.services.citation_service import CitationRenderResult, citation_service
@@ -255,28 +256,41 @@ class MessagingService:
         )
 
         prepared_latex_content = prepare_latex_body(llm_content)
-        latex_document_path = (
-            text_to_img(prepared_latex_content)
+        latex_document_paths = (
+            text_to_images(prepared_latex_content)
             if prepared_latex_content is not None
             else None
         )
 
-        if latex_document_path:
-            image_sent = await whatsapp_client.send_image_message(
-                wa_id=user.wa_id,
-                image_path=latex_document_path,
-                img_type=ImageType.PNG,
-            )
-            if image_sent:
-                record_messages_generated("chat_response_with_latex_image")
-                return
-            else:
+        if latex_document_paths:
+            for page_index, image_path in enumerate(latex_document_paths):
+                image_sent = await whatsapp_client.send_image_message(
+                    wa_id=user.wa_id,
+                    image_path=image_path,
+                    img_type=ImageType.PNG,
+                )
+                if image_sent:
+                    continue
+
+                for unsent_image_path in latex_document_paths[page_index + 1 :]:
+                    try:
+                        Path(unsent_image_path).unlink(missing_ok=True)
+                    except OSError as exc:
+                        self.logger.warning(
+                            "Failed to delete unsent LaTeX image %s: %s",
+                            unsent_image_path,
+                            exc,
+                        )
+
                 self.logger.warning(
                     "Falling back to plain text delivery; WhatsApp image send failed."
                 )
                 await whatsapp_client.send_message(user.wa_id, llm_content)
                 record_messages_generated("chat_response_with_latex_image_fallback")
                 return
+
+            record_messages_generated("chat_response_with_latex_image")
+            return
 
         else:
             self.logger.warning(

--- a/tests/test_image_delivery.py
+++ b/tests/test_image_delivery.py
@@ -1,9 +1,12 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import fitz
 import httpx
 import pytest
 
 import app.database.enums as enums
+import app.latex.latex_artifact_generator as latex_artifact_generator
 from app.clients.whatsapp_client import DocumentType, ImageType, WhatsAppClient
 from app.config import settings
 from app.database.models import Message, User
@@ -12,6 +15,7 @@ from app.latex.latex_artifact_generator import (
     _extract_latex_document_body,
     _extract_tectonic_error_context,
     prepare_latex_body,
+    text_to_images,
 )
 from app.services.messaging_service import MessagingService
 
@@ -207,8 +211,8 @@ async def test_handle_chat_message_falls_back_to_text_when_image_send_fails() ->
         ),
         patch("app.services.messaging_service.db.create_new_messages", AsyncMock()),
         patch(
-            "app.services.messaging_service.text_to_img",
-            return_value="/tmp/twiga_latex_image.png",
+            "app.services.messaging_service.text_to_images",
+            return_value=["/tmp/twiga_latex_image.png"],
         ),
         patch(
             "app.services.messaging_service.whatsapp_client.send_image_message",
@@ -235,6 +239,166 @@ async def test_handle_chat_message_falls_back_to_text_when_image_send_fails() ->
     mock_persist_visible.assert_awaited_once_with(
         user=user, content=llm_message.content, source_chunk_ids=None
     )
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_message_sends_all_latex_images_in_page_order() -> None:
+    service = MessagingService()
+    user = User(id=1, wa_id="255700000000", name="Teacher")
+    user_message = Message(user_id=1, role=enums.MessageRole.user, content="Solve")
+    llm_message = Message(
+        user_id=1,
+        role=enums.MessageRole.assistant,
+        content="\\frac{1}{2}",
+    )
+    image_paths = ["/tmp/page_1.png", "/tmp/page_2.png"]
+
+    with (
+        patch("app.services.messaging_service.llm_settings.agentic_mode", False),
+        patch(
+            "app.services.messaging_service.llm_client.generate_response",
+            AsyncMock(return_value=[llm_message]),
+        ),
+        patch("app.services.messaging_service.db.create_new_messages", AsyncMock()),
+        patch(
+            "app.services.messaging_service.text_to_images",
+            return_value=image_paths,
+        ),
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_image_message",
+            AsyncMock(return_value=True),
+        ) as mock_send_image,
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_message",
+            AsyncMock(),
+        ) as mock_send_message,
+        patch.object(
+            service,
+            "_persist_visible_assistant_message",
+            AsyncMock(),
+        ),
+        patch(
+            "app.services.messaging_service.record_messages_generated"
+        ) as mock_record_messages,
+    ):
+        response = await service.handle_chat_message(
+            user=user, user_message=user_message
+        )
+
+    assert response.status_code == 200
+    assert mock_send_image.await_args_list == [
+        call(wa_id=user.wa_id, image_path=image_path, img_type=ImageType.PNG)
+        for image_path in image_paths
+    ]
+    mock_send_message.assert_not_awaited()
+    mock_record_messages.assert_called_once_with("chat_response_with_latex_image")
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_message_falls_back_to_text_after_page_send_failure(
+    tmp_path,
+) -> None:
+    service = MessagingService()
+    user = User(id=1, wa_id="255700000000", name="Teacher")
+    user_message = Message(user_id=1, role=enums.MessageRole.user, content="Solve")
+    llm_message = Message(
+        user_id=1,
+        role=enums.MessageRole.assistant,
+        content="\\frac{1}{2}",
+    )
+    image_paths = [str(tmp_path / f"page_{page}.png") for page in range(1, 4)]
+    for image_path in image_paths:
+        Path(image_path).write_bytes(b"image")
+
+    with (
+        patch("app.services.messaging_service.llm_settings.agentic_mode", False),
+        patch(
+            "app.services.messaging_service.llm_client.generate_response",
+            AsyncMock(return_value=[llm_message]),
+        ),
+        patch("app.services.messaging_service.db.create_new_messages", AsyncMock()),
+        patch(
+            "app.services.messaging_service.text_to_images",
+            return_value=image_paths,
+        ),
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_image_message",
+            AsyncMock(side_effect=[True, False]),
+        ) as mock_send_image,
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_message",
+            AsyncMock(),
+        ) as mock_send_message,
+        patch.object(
+            service,
+            "_persist_visible_assistant_message",
+            AsyncMock(),
+        ),
+        patch(
+            "app.services.messaging_service.record_messages_generated"
+        ) as mock_record_messages,
+    ):
+        response = await service.handle_chat_message(
+            user=user, user_message=user_message
+        )
+
+    assert response.status_code == 200
+    assert mock_send_image.await_count == 2
+    mock_send_message.assert_awaited_once_with(user.wa_id, llm_message.content)
+    assert not Path(image_paths[2]).exists()
+    mock_record_messages.assert_called_once_with(
+        "chat_response_with_latex_image_fallback"
+    )
+
+
+def test_text_to_images_returns_an_image_for_each_pdf_page(
+    tmp_path, monkeypatch
+) -> None:
+    pdf_path = tmp_path / "response.pdf"
+    document = fitz.open()
+    document.new_page()
+    document.new_page()
+    document.save(pdf_path)
+    document.close()
+    monkeypatch.setattr(
+        latex_artifact_generator,
+        "_should_persist_latex_image_locally",
+        lambda: False,
+    )
+
+    with patch(
+        "app.latex.latex_artifact_generator.compile_latex_to_pdf",
+        return_value=str(pdf_path),
+    ):
+        image_paths = text_to_images("Ignored because compilation is mocked.")
+
+    try:
+        assert image_paths is not None
+        assert len(image_paths) == 2
+        assert all(Path(image_path).exists() for image_path in image_paths)
+    finally:
+        for image_path in image_paths or []:
+            Path(image_path).unlink(missing_ok=True)
+
+
+def test_text_to_images_cleans_compile_directory_on_failure(
+    tmp_path, monkeypatch
+) -> None:
+    compile_directory = tmp_path / "latex-compile"
+    compile_directory.mkdir()
+    monkeypatch.setattr(
+        latex_artifact_generator.tempfile,
+        "mkdtemp",
+        lambda: str(compile_directory),
+    )
+
+    with patch(
+        "app.latex.latex_artifact_generator.compile_latex_to_pdf",
+        side_effect=RuntimeError("Tectonic failed"),
+    ):
+        assert text_to_images("Invalid LaTeX") is None
+
+    assert not compile_directory.exists()
 
 
 def test_extract_latex_document_body() -> None:


### PR DESCRIPTION
## Summary
- Long LaTeX chat responses (e.g. `solve_equation`) compiled to a multi-page PDF, but only the first page was rasterized and sent. Later pages were discarded with no warning.
- Render every PDF page to its own PNG (existing 5 MB / DPI fallback, per page) and send the images in page order.
- If any image send fails, stop, clean up unsent files, and fall back to the existing chunked text path.

Lesson-plan PDF delivery is intentionally out of scope and should be a follow-up (`feat/lesson-plan-pdf-delivery`).

## Test plan
- [ ] `pytest tests/test_image_delivery.py tests/services/test_messaging_service.py`
- [ ] Ask for a long equation solution in mock WhatsApp and confirm multiple images arrive in order
- [ ] Confirm a short one-page LaTeX reply still sends a single image
- [ ] Confirm a failed image send still delivers the full text fallback (no orphan temp files)