### PR TITLE
fix: restore exercise generation and improve failure logging

### DIFF
--- a/app/tools/tool_code/generate_exercise/main.py
+++ b/app/tools/tool_code/generate_exercise/main.py
@@ -45,8 +45,8 @@ async def generate_exercise(
         logger.debug(
             f"Retrieved {len(retrieved_content)} exercise chunks, this is the first: {retrieved_content[0]}"
         )
-    except Exception as e:
-        logger.error(f"An error occurred when generating an exercise: {e}")
+    except Exception:
+        logger.exception("Failed to retrieve textbook content for an exercise")
         raise Exception(
             "Failed to find content from the textbooks to generate this exercise. Skipping."
         )
@@ -73,7 +73,7 @@ async def generate_exercise(
 
         response = await async_llm_request(
             messages=messages,
-            max_tokens=100,
+            max_tokens=2048,
             run_name="twiga_generate_exercise",
             metadata={
                 "tool": "generate_exercise",
@@ -87,11 +87,19 @@ async def generate_exercise(
                     len(retrieved_exercises) if "retrieved_exercises" in locals() else 0
                 ),
                 **prompt_manager.build_trace_metadata(
-                    system=system_prompt_name,
-                    user=user_prompt_name,
+                    system_prompt_name=system_prompt_name,
+                    user_prompt_name=user_prompt_name,
                 ),
             },
         )
+        if not response.content:
+            logger.error(
+                "Exercise generation returned empty content: "
+                "class_id=%s, response_metadata=%r, usage_metadata=%r",
+                class_id,
+                response.response_metadata,
+                response.usage_metadata,
+            )
         assert response.content
 
         # Convert content to string if it's not already
@@ -109,8 +117,8 @@ async def generate_exercise(
             return content
         else:
             return str(content)
-    except Exception as e:
-        logger.error(f"An error occurred when generating an exercise: {e}")
+    except Exception:
+        logger.exception("An error occurred when generating an exercise")
         raise Exception("An error occurred when generating this exercise. Skipping.")
 
 

--- a/app/tools/tool_code/generate_exercise/main.py
+++ b/app/tools/tool_code/generate_exercise/main.py
@@ -19,7 +19,8 @@ async def generate_exercise(
     try:
         # Retrieve the resources for the class
         resource_ids = await db.get_class_resources(class_id)
-        assert resource_ids
+        if not resource_ids:
+            raise ValueError(f"No textbook resources found for class {class_id}")
 
         # Retrieve the relevant content and exercises
         retrieved_content = await vector_search(
@@ -40,16 +41,17 @@ async def generate_exercise(
         )
 
         logger.debug(
-            f"Retrieved {len(retrieved_content)} content chunks, this is the first: {retrieved_content[0]}"
+            "Retrieved %s content chunks and %s exercise chunks",
+            len(retrieved_content),
+            len(retrieved_exercises),
         )
-        logger.debug(
-            f"Retrieved {len(retrieved_content)} exercise chunks, this is the first: {retrieved_content[0]}"
-        )
-    except Exception:
+        if not retrieved_content:
+            raise ValueError("No textbook content found for the exercise")
+    except Exception as exc:
         logger.exception("Failed to retrieve textbook content for an exercise")
         raise Exception(
             "Failed to find content from the textbooks to generate this exercise. Skipping."
-        )
+        ) from exc
 
     try:
         # Format the context and prompt
@@ -92,16 +94,6 @@ async def generate_exercise(
                 ),
             },
         )
-        if not response.content:
-            logger.error(
-                "Exercise generation returned empty content: "
-                "class_id=%s, response_metadata=%r, usage_metadata=%r",
-                class_id,
-                response.response_metadata,
-                response.usage_metadata,
-            )
-        assert response.content
-
         # Convert content to string if it's not already
         content = response.content
         if isinstance(content, list):
@@ -112,14 +104,26 @@ async def generate_exercise(
                     content_str += item
                 elif isinstance(item, dict) and "text" in item:
                     content_str += item["text"]
-            return content_str
         elif isinstance(content, str):
-            return content
+            content_str = content
         else:
-            return str(content)
-    except Exception:
+            content_str = str(content) if content is not None else ""
+
+        if not content_str.strip():
+            logger.error(
+                "Exercise generation returned empty content: "
+                "class_id=%s, response_metadata=%r, usage_metadata=%r",
+                class_id,
+                response.response_metadata,
+                response.usage_metadata,
+            )
+            raise ValueError("Exercise generation returned no usable text")
+        return content_str
+    except Exception as exc:
         logger.exception("An error occurred when generating an exercise")
-        raise Exception("An error occurred when generating this exercise. Skipping.")
+        raise Exception(
+            "An error occurred when generating this exercise. Skipping."
+        ) from exc
 
 
 def _format_context(


### PR DESCRIPTION
**Description**:

`generate_exercise` failed after textbook retrieval because it passed outdated keyword arguments to `PromptManager.build_trace_metadata()`. This raised a `TypeError` before any LLM request.

Correcting those arguments exposed a second issue: the 100-token output limit was exhausted during reasoning, leaving empty content and triggering an `AssertionError`. Logs confirmed `finish_reason='length'`, with 99 reasoning tokens out of 100 completion tokens.
This PR:
- Updates the metadata arguments to `system_prompt_name` and `user_prompt_name`.
- Increases the output budget from 100 to 2048 tokens.
- Adds traceback logging for retrieval and generation failures.
- Logs response metadata and token usage when content is empty.

**Validation**: Reproduced both failures locally. After the changes, a mock-WhatsApp request produced 10 nonempty exercise responses and a final answer without generation errors. Python syntax and whitespace checks passed.

Logs:
[old_logs.txt](https://github.com/user-attachments/files/31929640/old_logs.txt)

[new_logs.txt](https://github.com/user-attachments/files/31929639/new_logs.txt)


Screenshots:

### Old
<img width="1337" height="1863" alt="Before" src="https://github.com/user-attachments/assets/0156a64c-5029-4a8c-b97d-be4f8ba69393" />

### New
<img width="1329" height="1852" alt="After" src="https://github.com/user-attachments/assets/9c88fdcb-5184-4b18-9d99-40f3713acab1" />
