### PR TITLE
Feat/lesson plan pdf delivery

### DIFF
--- a/app/assets/strings/english.yml
+++ b/app/assets/strings/english.yml
@@ -32,6 +32,7 @@ settings:
 tools:
   create_lesson_plan:
     notification: "📋 Creating a lesson plan, please hold..."
+    delivery_success: "Here is your lesson plan as a PDF."
   generate_exercise:
     notification: "📑 Generating exercises from the course content, please hold..."
   generate_necta_style_exam:

--- a/app/services/lesson_plan_pdf_generation_service.py
+++ b/app/services/lesson_plan_pdf_generation_service.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from app.latex.latex_artifact_generator import compile_latex_to_pdf
+from app.services.exam_rendering.latex_exam_pdf_rendering import normalize_inline_text
+
+
+def build_lesson_plan_latex_body(plan: dict[str, Any]) -> str:
+    lines: list[str] = []
+
+    title = normalize_inline_text(plan.get("lesson_title", "Lesson Plan"))
+    lines.append(rf"\section*{{{title}}}")
+    lines.append("")
+
+    metadata_parts: list[str] = []
+    subject = normalize_inline_text(plan.get("subject", ""))
+    topic = normalize_inline_text(plan.get("topic", ""))
+    duration = plan.get("duration_minutes", 45)
+    if subject:
+        metadata_parts.append(rf"\textbf{{Subject:}} {subject}")
+    if topic:
+        metadata_parts.append(rf"\textbf{{Topic:}} {topic}")
+    metadata_parts.append(
+        rf"\textbf{{Duration:}} {normalize_inline_text(duration)} minutes"
+    )
+    lines.append(r"\noindent " + r" \\ ".join(metadata_parts))
+    lines.append("")
+
+    objectives = plan.get("learning_objectives", [])
+    if isinstance(objectives, list) and objectives:
+        lines.append(r"\subsection*{Learning Objectives}")
+        lines.append(r"Students will be able to:")
+        lines.extend(_enumerate_items(objectives))
+        lines.append("")
+
+    key_concepts = plan.get("key_concepts", [])
+    if isinstance(key_concepts, list) and key_concepts:
+        lines.append(r"\subsection*{Key Concepts}")
+        lines.extend(_itemize_items(key_concepts))
+        lines.append("")
+
+    materials = plan.get("materials_preparation", {})
+    if isinstance(materials, dict):
+        materials_needed = materials.get("materials_needed", [])
+        teacher_prep = materials.get("teacher_preparation", [])
+        if (isinstance(materials_needed, list) and materials_needed) or (
+            isinstance(teacher_prep, list) and teacher_prep
+        ):
+            lines.append(r"\subsection*{Materials \& Preparation}")
+            if isinstance(materials_needed, list) and materials_needed:
+                lines.append(r"\subsubsection*{Materials needed}")
+                lines.extend(_itemize_items(materials_needed))
+            if isinstance(teacher_prep, list) and teacher_prep:
+                lines.append(r"\subsubsection*{Teacher preparation}")
+                lines.extend(_itemize_items(teacher_prep))
+            lines.append("")
+
+    lesson_flow = plan.get("lesson_flow", [])
+    if isinstance(lesson_flow, list) and lesson_flow:
+        lines.append(r"\subsection*{Lesson Flow}")
+        for section in lesson_flow:
+            if not isinstance(section, dict):
+                continue
+            section_title = normalize_inline_text(section.get("title", "Section"))
+            duration_minutes = section.get("duration_minutes", "")
+            heading = section_title
+            if duration_minutes != "" and duration_minutes is not None:
+                heading = (
+                    f"{section_title} "
+                    f"({normalize_inline_text(duration_minutes)} min)"
+                )
+            lines.append(rf"\subsubsection*{{{heading}}}")
+            lines.extend(_build_activity_list(section.get("activities", [])))
+            lines.append("")
+
+    homework = plan.get("homework", [])
+    if isinstance(homework, list) and homework:
+        lines.append(r"\subsection*{Homework}")
+        lines.extend(_itemize_items(homework))
+        lines.append("")
+
+    return "\n".join(line for line in lines if line is not None).strip() + "\n"
+
+
+def render_lesson_plan_pdf(plan: dict[str, Any], output_path: str | Path) -> None:
+    latex_body = build_lesson_plan_latex_body(plan)
+    if not latex_body.strip():
+        raise ValueError("Lesson plan produced an empty LaTeX body.")
+
+    destination = Path(output_path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="twiga-lesson-plan-pdf-") as temp_dir:
+        compiled_pdf = compile_latex_to_pdf(latex_body, temp_dir)
+        shutil.copyfile(compiled_pdf, destination)
+
+
+def _itemize_items(items: list[Any]) -> list[str]:
+    lines = [r"\begin{itemize}"]
+    for item in items:
+        text = normalize_inline_text(item)
+        if text:
+            lines.append(rf"  \item {text}")
+    lines.append(r"\end{itemize}")
+    return lines if len(lines) > 2 else []
+
+
+def _enumerate_items(items: list[Any]) -> list[str]:
+    lines = [r"\begin{enumerate}"]
+    for item in items:
+        text = normalize_inline_text(item)
+        if text:
+            lines.append(rf"  \item {text}")
+    lines.append(r"\end{enumerate}")
+    return lines if len(lines) > 2 else []
+
+
+def _build_activity_list(activities: Any) -> list[str]:
+    if not isinstance(activities, list) or not activities:
+        return []
+
+    lines = [r"\begin{itemize}"]
+    for activity in activities:
+        if isinstance(activity, str):
+            text = normalize_inline_text(activity)
+            if text:
+                lines.append(rf"  \item {text}")
+            continue
+
+        if not isinstance(activity, dict):
+            continue
+
+        activity_type = str(activity.get("type") or "").strip().lower()
+        if activity_type == "exercise":
+            prompt = normalize_inline_text(activity.get("prompt", ""))
+            answer = normalize_inline_text(activity.get("answer", ""))
+            if prompt:
+                lines.append(rf"  \item \textbf{{Exercise:}} {prompt}")
+            if answer:
+                lines.append(rf"  \item \textit{{Answer:}} {answer}")
+            continue
+
+        content = activity.get("content") or activity.get("prompt")
+        text = normalize_inline_text(content)
+        if text:
+            lines.append(rf"  \item {text}")
+
+    lines.append(r"\end{itemize}")
+    return lines if len(lines) > 2 else []

--- a/app/services/messaging_service.py
+++ b/app/services/messaging_service.py
@@ -1,4 +1,7 @@
+import json
 import logging
+import os
+import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -25,7 +28,9 @@ from app.services.exam_delivery_service import (
     exam_delivery_service,
 )
 from app.services.flows.flow_service import flow_client
+from app.services.lesson_plan_pdf_generation_service import render_lesson_plan_pdf
 from app.tools.registry import ToolName
+from app.tools.tool_code.create_lesson_plan.main import format_lesson_plan_as_text
 from app.utils.string_manager import StringCategory, strings
 
 
@@ -139,6 +144,13 @@ class MessagingService:
 
         if self._should_handle_exam_delivery(llm_responses, llm_content):
             await self._handle_exam_delivery(user, llm_content)
+            return JSONResponse(content={"status": "ok"}, status_code=200)
+
+        if self._should_handle_lesson_plan_delivery(llm_responses):
+            await self._handle_lesson_plan_delivery(
+                user=user,
+                llm_responses=llm_responses,
+            )
             return JSONResponse(content={"status": "ok"}, status_code=200)
 
         llm_content = await self._handle_citations(
@@ -363,6 +375,105 @@ class MessagingService:
             msg.role == enums.MessageRole.tool and msg.tool_name == exam_tool_name
             for msg in llm_responses
         )
+
+    def _should_handle_lesson_plan_delivery(
+        self, llm_responses: list[models.Message]
+    ) -> bool:
+        return self._get_successful_lesson_plan(llm_responses) is not None
+
+    def _get_successful_lesson_plan(
+        self, llm_responses: list[models.Message]
+    ) -> dict | None:
+        tool_name = ToolName.create_lesson_plan.value
+        for message in reversed(llm_responses):
+            if message.role != enums.MessageRole.tool or message.tool_name != tool_name:
+                continue
+            content = (message.content or "").strip()
+            if not content:
+                continue
+            try:
+                payload = json.loads(content)
+            except json.JSONDecodeError:
+                self.logger.warning(
+                    "Ignoring create_lesson_plan tool result that is not valid JSON."
+                )
+                continue
+            if not isinstance(payload, dict) or payload.get("error"):
+                continue
+            return payload
+        return None
+
+    async def _handle_lesson_plan_delivery(
+        self,
+        user: models.User,
+        llm_responses: list[models.Message],
+    ) -> None:
+        lesson_plan = self._get_successful_lesson_plan(llm_responses)
+        if lesson_plan is None:
+            self.logger.warning(
+                "Lesson plan delivery requested, but no successful tool result was found."
+            )
+            return
+
+        pdf_file_descriptor, pdf_path = tempfile.mkstemp(
+            prefix="twiga_lesson_plan_", suffix=".pdf"
+        )
+        os.close(pdf_file_descriptor)
+        pdf_sent = False
+
+        try:
+            try:
+                render_lesson_plan_pdf(lesson_plan, pdf_path)
+            except Exception as exc:
+                self.logger.warning(
+                    "Failed to render lesson plan PDF; falling back to text delivery. "
+                    f"error={exc}"
+                )
+                record_messages_generated("lesson_plan_pdf_render_failed")
+            else:
+                pdf_sent = await whatsapp_client.send_document_message(
+                    wa_id=user.wa_id,
+                    document_path=pdf_path,
+                    doc_type=DocumentType.PDF,
+                    filename="lesson_plan.pdf",
+                    delete_local_file=True,
+                )
+                if not pdf_sent:
+                    self.logger.warning(
+                        "Failed to send lesson plan PDF; falling back to text delivery."
+                    )
+                    record_messages_generated("lesson_plan_pdf_send_failed")
+        finally:
+            Path(pdf_path).unlink(missing_ok=True)
+
+        if pdf_sent:
+            delivery_message = self._build_lesson_plan_delivery_message()
+            await self._persist_visible_assistant_message(
+                user=user, content=delivery_message
+            )
+            await whatsapp_client.send_message(user.wa_id, delivery_message)
+            record_messages_generated("lesson_plan_pdf_sent")
+            record_messages_generated("chat_response")
+            return
+
+        plan_text = format_lesson_plan_as_text(lesson_plan)
+        await self._persist_visible_assistant_message(user=user, content=plan_text)
+        sent = await whatsapp_client.send_message(user.wa_id, plan_text)
+        if sent:
+            record_messages_generated("chat_response")
+
+    def _build_lesson_plan_delivery_message(self) -> str:
+        tool_name = ToolName.create_lesson_plan.value
+        tool_strings = strings.get_category(StringCategory.TOOLS).get(tool_name)
+        if isinstance(tool_strings, dict):
+            delivery_message = tool_strings.get("delivery_success")
+            if isinstance(delivery_message, str) and delivery_message.strip():
+                return delivery_message
+
+        self.logger.error(
+            f"Missing lesson plan delivery string for tool '{tool_name}'."
+        )
+        return "Here is your lesson plan as a PDF."
 
     async def _handle_exam_delivery(self, user: models.User, llm_content: str) -> None:
         delivery_marker: ExamDeliveryMarker = (

--- a/app/tools/tool_code/create_lesson_plan/main.py
+++ b/app/tools/tool_code/create_lesson_plan/main.py
@@ -25,7 +25,7 @@ async def create_lesson_plan(
     class_context: Optional[list[str]] = None,
 ) -> str:
     """
-    Create a structured lesson plan and return a rendered string.
+    Create a structured lesson plan and return it as a JSON string.
     """
     try:
         resource_ids = await db.get_class_resources(class_id)
@@ -147,7 +147,7 @@ async def create_lesson_plan(
             f"Successfully created lesson plan for class_id={class_id}, subject={subject}, topic={topic}, lesson_plan={lesson_plan}"
         )
 
-        return _lesson_plan_json_to_string(lesson_plan)
+        return json.dumps(lesson_plan, ensure_ascii=False)
     except Exception as e:
         logger.error(
             f"Error creating lesson plan for class_id={class_id}, subject={subject}, topic={topic}: {e}",
@@ -262,7 +262,8 @@ def _parse_json_response(content: str, step: str = "unknown") -> dict[str, Any]:
             raise
 
 
-def _lesson_plan_json_to_string(lesson_plan: dict[str, Any]) -> str:
+def format_lesson_plan_as_text(lesson_plan: dict[str, Any]) -> str:
+    """Format a structured lesson plan as readable plain text for chat fallback."""
     lines: list[str] = []
 
     lines.append(f"Lesson Plan: {lesson_plan.get('lesson_title', '')}")

--- a/tests/services/test_lesson_plan_pdf_generation_service.py
+++ b/tests/services/test_lesson_plan_pdf_generation_service.py
@@ -1,0 +1,118 @@
+from unittest.mock import patch
+
+from app.services.lesson_plan_pdf_generation_service import (
+    build_lesson_plan_latex_body,
+    render_lesson_plan_pdf,
+)
+from app.tools.tool_code.create_lesson_plan.main import format_lesson_plan_as_text
+
+SAMPLE_LESSON_PLAN = {
+    "lesson_title": "Introduction to Algebra",
+    "subject": "Mathematics",
+    "topic": "Equations",
+    "duration_minutes": 45,
+    "learning_objectives": [
+        "Solve linear equations",
+        "Explain the balance method",
+    ],
+    "key_concepts": ["Balance method", "Inverse operations"],
+    "materials_preparation": {
+        "materials_needed": ["Whiteboard", "Markers"],
+        "teacher_preparation": ["Prepare worked examples"],
+    },
+    "lesson_flow": [
+        {
+            "title": "Introduction",
+            "duration_minutes": 10,
+            "activities": [
+                {"type": "instruction", "content": "Review prior knowledge"},
+                {
+                    "type": "exercise",
+                    "prompt": "Solve $x + 2 = 5$",
+                    "answer": "$x = 3$",
+                },
+            ],
+        },
+        {
+            "title": "Practice",
+            "duration_minutes": 20,
+            "activities": ["Work through example 2"],
+        },
+    ],
+    "homework": ["Complete exercise set A"],
+}
+
+
+def test_build_lesson_plan_latex_body_uses_headings_and_lists() -> None:
+    latex = build_lesson_plan_latex_body(SAMPLE_LESSON_PLAN)
+
+    assert r"\section*{Introduction to Algebra}" in latex
+    assert r"\textbf{Subject:} Mathematics" in latex
+    assert r"\textbf{Topic:} Equations" in latex
+    assert r"\textbf{Duration:} 45 minutes" in latex
+    assert r"\subsection*{Learning Objectives}" in latex
+    assert r"\begin{enumerate}" in latex
+    assert r"\item Solve linear equations" in latex
+    assert r"\subsection*{Key Concepts}" in latex
+    assert r"\begin{itemize}" in latex
+    assert r"\item Balance method" in latex
+    assert r"\subsection*{Materials \& Preparation}" in latex
+    assert r"\subsubsection*{Materials needed}" in latex
+    assert r"\subsubsection*{Teacher preparation}" in latex
+    assert r"\subsection*{Lesson Flow}" in latex
+    assert r"\subsubsection*{Introduction (10 min)}" in latex
+    assert r"\item Review prior knowledge" in latex
+    assert r"\item \textbf{Exercise:} Solve $x + 2 = 5$" in latex
+    assert r"\item \textit{Answer:} $x = 3$" in latex
+    assert r"\subsubsection*{Practice (20 min)}" in latex
+    assert r"\item Work through example 2" in latex
+    assert r"\subsection*{Homework}" in latex
+    assert r"\item Complete exercise set A" in latex
+
+
+def test_build_lesson_plan_latex_body_escapes_special_chars_and_keeps_math() -> None:
+    plan = {
+        "lesson_title": "Rates & Ratios",
+        "subject": "Mathematics",
+        "topic": "Percentages",
+        "duration_minutes": 40,
+        "learning_objectives": ["Use $a^2 + b^2 = c^2$ and 50% growth"],
+        "key_concepts": ["cost & benefit"],
+    }
+
+    latex = build_lesson_plan_latex_body(plan)
+
+    assert r"\section*{Rates \& Ratios}" in latex
+    assert r"\textbf{Subject:} Mathematics" in latex
+    assert r"$a^2 + b^2 = c^2$" in latex
+    assert r"50\% growth" in latex
+    assert r"cost \& benefit" in latex
+
+
+def test_format_lesson_plan_as_text_keeps_readable_fallback() -> None:
+    text = format_lesson_plan_as_text(SAMPLE_LESSON_PLAN)
+
+    assert "Lesson Plan: Introduction to Algebra" in text
+    assert "Learning Objectives:" in text
+    assert "1. Solve linear equations" in text
+    assert "- Balance method" in text
+    assert "Exercise: Solve $x + 2 = 5$" in text
+    assert "Answer: $x = 3$" in text
+
+
+def test_render_lesson_plan_pdf_copies_compiled_output(tmp_path) -> None:
+    compiled_pdf = tmp_path / "compiled.pdf"
+    compiled_pdf.write_bytes(b"%PDF-1.4")
+    output_path = tmp_path / "lesson_plan.pdf"
+
+    with patch(
+        "app.services.lesson_plan_pdf_generation_service.compile_latex_to_pdf",
+        return_value=str(compiled_pdf),
+    ) as mock_compile:
+        render_lesson_plan_pdf(SAMPLE_LESSON_PLAN, output_path)
+
+    mock_compile.assert_called_once()
+    latex_body = mock_compile.call_args.args[0]
+    assert r"\section*{Introduction to Algebra}" in latex_body
+    assert output_path.exists()
+    assert output_path.read_bytes() == b"%PDF-1.4"

--- a/tests/services/test_messaging_service.py
+++ b/tests/services/test_messaging_service.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -9,6 +10,35 @@ from app.database.models import Message, User
 from app.services.citation_service import CitationRenderResult
 from app.services.exam_delivery_service import ExamPDFDeliveryDetails
 from app.services.messaging_service import MessagingService
+from app.tools.tool_code.create_lesson_plan.main import format_lesson_plan_as_text
+
+SAMPLE_LESSON_PLAN = {
+    "lesson_title": "Introduction to Algebra",
+    "subject": "Mathematics",
+    "topic": "Equations",
+    "duration_minutes": 45,
+    "learning_objectives": ["Solve linear equations"],
+    "key_concepts": ["Balance method"],
+    "materials_preparation": {
+        "materials_needed": ["Whiteboard"],
+        "teacher_preparation": ["Prepare examples"],
+    },
+    "lesson_flow": [
+        {
+            "title": "Introduction",
+            "duration_minutes": 10,
+            "activities": [
+                {"type": "instruction", "content": "Review prior knowledge"},
+                {
+                    "type": "exercise",
+                    "prompt": "Solve $x + 2 = 5$",
+                    "answer": "$x = 3$",
+                },
+            ],
+        }
+    ],
+    "homework": ["Complete exercise 1"],
+}
 
 
 @pytest.mark.asyncio
@@ -686,3 +716,293 @@ async def test_handle_chat_message_marker_only_skips_text_send_after_documents()
         user.wa_id,
         "Here is your practice exam in Geography on topics: Climate, Weather.",
     )
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_message_sends_lesson_plan_pdf_from_successful_tool() -> None:
+    service = MessagingService()
+    user = User(id=21, wa_id="255700000201", name="Teacher")
+    user_message = Message(
+        user_id=21,
+        role=enums.MessageRole.user,
+        content="Create a geography lesson plan",
+    )
+    tool_message = Message(
+        user_id=21,
+        role=enums.MessageRole.tool,
+        content=json.dumps(SAMPLE_LESSON_PLAN),
+        tool_name="create_lesson_plan",
+        tool_call_id="call_lesson_plan",
+    )
+    final_message = Message(
+        user_id=21,
+        role=enums.MessageRole.assistant,
+        content="Here is your lesson plan with $d = vt$.",
+    )
+    rendered_paths: list[Path] = []
+
+    def fake_render(plan, output_path) -> None:
+        assert plan == SAMPLE_LESSON_PLAN
+        path = Path(output_path)
+        path.write_bytes(b"%PDF-1.4")
+        rendered_paths.append(path)
+
+    with (
+        patch("app.services.messaging_service.llm_settings.agentic_mode", False),
+        patch(
+            "app.services.messaging_service.llm_client.generate_response",
+            AsyncMock(return_value=[tool_message, final_message]),
+        ),
+        patch("app.services.messaging_service.db.create_new_messages", AsyncMock()),
+        patch(
+            "app.services.messaging_service.render_lesson_plan_pdf",
+            side_effect=fake_render,
+        ) as mock_render,
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_document_message",
+            AsyncMock(return_value=True),
+        ) as mock_send_document,
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_image_message",
+            AsyncMock(return_value=True),
+        ) as mock_send_image,
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_message",
+            AsyncMock(return_value=True),
+        ) as mock_send_message,
+        patch.object(
+            service,
+            "_persist_visible_assistant_message",
+            AsyncMock(),
+        ) as mock_persist_visible,
+        patch(
+            "app.services.messaging_service.record_messages_generated"
+        ) as mock_record_messages,
+    ):
+        response = await service.handle_chat_message(
+            user=user, user_message=user_message
+        )
+
+    assert response.status_code == 200
+    mock_render.assert_called_once()
+    mock_send_document.assert_awaited_once()
+    send_document_kwargs = mock_send_document.await_args.kwargs
+    assert send_document_kwargs["wa_id"] == user.wa_id
+    assert send_document_kwargs["filename"] == "lesson_plan.pdf"
+    mock_send_image.assert_not_awaited()
+    mock_send_message.assert_awaited_once_with(
+        user.wa_id,
+        "Here is your lesson plan as a PDF.",
+    )
+    mock_persist_visible.assert_awaited_once_with(
+        user=user, content="Here is your lesson plan as a PDF."
+    )
+    mock_record_messages.assert_any_call("lesson_plan_pdf_sent")
+    assert rendered_paths
+    assert not rendered_paths[0].exists()
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_message_failed_lesson_plan_tool_does_not_send_pdf() -> None:
+    service = MessagingService()
+    user = User(id=22, wa_id="255700000202", name="Teacher")
+    user_message = Message(
+        user_id=22,
+        role=enums.MessageRole.user,
+        content="Create a lesson plan",
+    )
+    tool_message = Message(
+        user_id=22,
+        role=enums.MessageRole.tool,
+        content='{"error": "Failed to create lesson plan. Please try again."}',
+        tool_name="create_lesson_plan",
+        tool_call_id="call_lesson_plan",
+    )
+    final_message = Message(
+        user_id=22,
+        role=enums.MessageRole.assistant,
+        content="Sorry, I could not create the lesson plan.",
+    )
+
+    with (
+        patch("app.services.messaging_service.llm_settings.agentic_mode", False),
+        patch(
+            "app.services.messaging_service.llm_client.generate_response",
+            AsyncMock(return_value=[tool_message, final_message]),
+        ),
+        patch("app.services.messaging_service.db.create_new_messages", AsyncMock()),
+        patch(
+            "app.services.messaging_service.citation_service.render_citations",
+            AsyncMock(
+                return_value=CitationRenderResult(
+                    marker_found=False,
+                    rendered_content=final_message.content,
+                    ordered_chunk_ids=[],
+                    valid_reference_count=0,
+                    invalid_reference_count=0,
+                )
+            ),
+        ),
+        patch(
+            "app.services.messaging_service.render_lesson_plan_pdf",
+        ) as mock_render,
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_document_message",
+            AsyncMock(),
+        ) as mock_send_document,
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_message",
+            AsyncMock(return_value=True),
+        ) as mock_send_message,
+        patch.object(
+            service,
+            "_persist_visible_assistant_message",
+            AsyncMock(),
+        ),
+        patch("app.services.messaging_service.looks_like_latex", return_value=False),
+        patch("app.services.messaging_service.record_messages_generated"),
+    ):
+        response = await service.handle_chat_message(
+            user=user, user_message=user_message
+        )
+
+    assert response.status_code == 200
+    mock_render.assert_not_called()
+    mock_send_document.assert_not_awaited()
+    mock_send_message.assert_awaited_once_with(user.wa_id, final_message.content)
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_message_lesson_plan_pdf_render_failure_falls_back_to_text() -> (
+    None
+):
+    service = MessagingService()
+    user = User(id=23, wa_id="255700000203", name="Teacher")
+    user_message = Message(
+        user_id=23,
+        role=enums.MessageRole.user,
+        content="Create a lesson plan",
+    )
+    tool_message = Message(
+        user_id=23,
+        role=enums.MessageRole.tool,
+        content=json.dumps(SAMPLE_LESSON_PLAN),
+        tool_name="create_lesson_plan",
+        tool_call_id="call_lesson_plan",
+    )
+    final_message = Message(
+        user_id=23,
+        role=enums.MessageRole.assistant,
+        content="Here is your lesson plan.",
+    )
+    expected_text = format_lesson_plan_as_text(SAMPLE_LESSON_PLAN)
+
+    with (
+        patch("app.services.messaging_service.llm_settings.agentic_mode", False),
+        patch(
+            "app.services.messaging_service.llm_client.generate_response",
+            AsyncMock(return_value=[tool_message, final_message]),
+        ),
+        patch("app.services.messaging_service.db.create_new_messages", AsyncMock()),
+        patch(
+            "app.services.messaging_service.render_lesson_plan_pdf",
+            side_effect=RuntimeError("Tectonic failed"),
+        ),
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_document_message",
+            AsyncMock(),
+        ) as mock_send_document,
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_message",
+            AsyncMock(return_value=True),
+        ) as mock_send_message,
+        patch.object(
+            service,
+            "_persist_visible_assistant_message",
+            AsyncMock(),
+        ) as mock_persist_visible,
+        patch(
+            "app.services.messaging_service.record_messages_generated"
+        ) as mock_record_messages,
+    ):
+        response = await service.handle_chat_message(
+            user=user, user_message=user_message
+        )
+
+    assert response.status_code == 200
+    mock_send_document.assert_not_awaited()
+    mock_send_message.assert_awaited_once_with(user.wa_id, expected_text)
+    mock_persist_visible.assert_awaited_once_with(user=user, content=expected_text)
+    mock_record_messages.assert_any_call("lesson_plan_pdf_render_failed")
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_message_lesson_plan_pdf_send_failure_falls_back_to_text() -> (
+    None
+):
+    service = MessagingService()
+    user = User(id=24, wa_id="255700000204", name="Teacher")
+    user_message = Message(
+        user_id=24,
+        role=enums.MessageRole.user,
+        content="Create a lesson plan",
+    )
+    tool_message = Message(
+        user_id=24,
+        role=enums.MessageRole.tool,
+        content=json.dumps(SAMPLE_LESSON_PLAN),
+        tool_name="create_lesson_plan",
+        tool_call_id="call_lesson_plan",
+    )
+    final_message = Message(
+        user_id=24,
+        role=enums.MessageRole.assistant,
+        content="Here is your lesson plan.",
+    )
+    expected_text = format_lesson_plan_as_text(SAMPLE_LESSON_PLAN)
+    rendered_paths: list[Path] = []
+
+    def fake_render(plan, output_path) -> None:
+        path = Path(output_path)
+        path.write_bytes(b"%PDF-1.4")
+        rendered_paths.append(path)
+
+    with (
+        patch("app.services.messaging_service.llm_settings.agentic_mode", False),
+        patch(
+            "app.services.messaging_service.llm_client.generate_response",
+            AsyncMock(return_value=[tool_message, final_message]),
+        ),
+        patch("app.services.messaging_service.db.create_new_messages", AsyncMock()),
+        patch(
+            "app.services.messaging_service.render_lesson_plan_pdf",
+            side_effect=fake_render,
+        ),
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_document_message",
+            AsyncMock(return_value=False),
+        ) as mock_send_document,
+        patch(
+            "app.services.messaging_service.whatsapp_client.send_message",
+            AsyncMock(return_value=True),
+        ) as mock_send_message,
+        patch.object(
+            service,
+            "_persist_visible_assistant_message",
+            AsyncMock(),
+        ) as mock_persist_visible,
+        patch(
+            "app.services.messaging_service.record_messages_generated"
+        ) as mock_record_messages,
+    ):
+        response = await service.handle_chat_message(
+            user=user, user_message=user_message
+        )
+
+    assert response.status_code == 200
+    mock_send_document.assert_awaited_once()
+    mock_send_message.assert_awaited_once_with(user.wa_id, expected_text)
+    mock_persist_visible.assert_awaited_once_with(user=user, content=expected_text)
+    mock_record_messages.assert_any_call("lesson_plan_pdf_send_failed")
+    assert rendered_paths
+    assert not rendered_paths[0].exists()


### PR DESCRIPTION
## Summary

This PR delivers generated lesson plans as formatted PDF documents in WhatsApp.

Previously, the lesson-plan tool converted its structured JSON result into plain text before rendering. The generic LaTeX renderer could compile that text into a PDF, but it could not infer document structure: headings appeared as normal text, lists ran together, and exercises were difficult to scan.

This change preserves the structured lesson-plan result until PDF generation. A dedicated renderer now maps known lesson-plan fields to a consistent document layout:

- Title, subject, topic, and duration
- Numbered learning objectives
- Key-concept and materials lists
- Teacher-preparation section
- Time-structured lesson-flow sections
- Exercise and answer styling
- Homework list

The generated PDF is uploaded using the existing WhatsApp document-delivery path. It is temporary: the local file is removed after sending, and no lesson-plan PDFs or new lesson-plan records are permanently stored.

## Failure behavior

- If PDF rendering fails, Twiga sends the readable plain-text lesson plan instead.
- If WhatsApp document upload fails, Twiga sends the same text fallback.
- A failed `create_lesson_plan` tool call does not attempt PDF generation.