### PR TITLE
Release 0.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twiga"
-version = "0.2.3"
+version = "0.2.4"
 description = "A WhatsApp chatbot for Tanzanian Teachers"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1867,7 +1867,7 @@ wheels = [
 
 [[package]]
 name = "twiga"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Patch release of everything currently on `development` that is not on `main` (lesson-plan PDFs, exam delivery, tool-progress fixes, duplicate-message fixes, LaTeX/WhatsApp fixes, and today's caption fix).
- Version bump `0.2.3` → `0.2.4`.

Merging this PR triggers the release workflow: `development` is merged into `main`, tagged `v0.2.4`, and production deploys on Render.

## Test plan
- [ ] CI is green
- [ ] Merge this PR (that is the deploy)