### PR TITLE
chore: bump version to 0.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twiga"
-version = "0.2.3"
+version = "0.2.4"
 description = "A WhatsApp chatbot for Tanzanian Teachers"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1867,7 +1867,7 @@ wheels = [
 
 [[package]]
 name = "twiga"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Patch release of `development` onto `main`. Version `0.2.3` → `0.2.4`.

### Lesson plans and document delivery
- Generated lesson plans are rendered as structured PDFs and sent as WhatsApp documents, with a plain-text fallback if rendering or upload fails (#337).
- Lesson-plan generation uses an 8,000-token output limit so the structured JSON is not truncated mid-response (#332).
- After a PDF is delivered, Twiga no longer sends a separate confirmation caption. That caption was being stored in conversation history and reused as a fake completion (#340).

### Chat and tool reliability
- Conversation history sent to the LLM includes only visible messages, so raw and rendered assistant copies are no longer both present (#333).
- Tool progress notifications are sent once per turn and are not written back into the LLM context (#339).
- `generate_exercise` no longer fails after retrieval: prompt-trace metadata arguments are corrected and the output budget is increased to 2,048 tokens (#336).
- Multi-page LaTeX replies send every rendered page as a WhatsApp image instead of dropping everything after page one (#335).

### Retrieval and prompts
- `search_knowledge` result size is configured in `base.yml` rather than hardcoded (#322).
- Active system prompts are v0.1: textbook lookup is required before subject-matter answers, lookup queries use topic terms only, and multilingual teacher input is accepted while replies stay in English (#326).